### PR TITLE
Add hero text with typewriter effect

### DIFF
--- a/components/HeroText.tsx
+++ b/components/HeroText.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Typewriter from 'typewriter-effect';
+
+const HeroText: React.FC = () => {
+  return (
+    <div className="absolute top-1/3 left-1/2 transform -translate-x-1/2 text-center z-10">
+      <h1 className="text-4xl md:text-6xl font-bold text-white">
+        Article6 is{' '}
+        <span className="text-green-400">
+          <Typewriter
+            options={{
+              strings: ['sustainable', 'innovative', 'profitable'],
+              autoStart: true,
+              loop: true,
+            }}
+          />
+        </span>
+      </h1>
+    </div>
+  );
+};
+
+export default HeroText;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import GlobeComponent from '../components/ThreeComponents/GlobeComponent/GlobeComponent';
+import HeroText from '../components/HeroText';
 import '../styles/globals.css';
 
 const HomePage = () => {
   return (
-    <div className="w-full h-screen ">
+    <div className="relative w-full h-screen">
       <ErrorBoundary>
         <GlobeComponent />
       </ErrorBoundary>
+      <HeroText />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create `HeroText` component with typewriter effect
- overlay `HeroText` on home page

## Testing
- `npm run lint`
- `npm run build` *(fails: 'its-fine' and 'BatchedMesh' import errors)*

------
https://chatgpt.com/codex/tasks/task_e_684dc7832cb483319e5649d6a0160082