### PR TITLE
Add hero text overlay

### DIFF
--- a/components/TypewriterText.tsx
+++ b/components/TypewriterText.tsx
@@ -4,14 +4,14 @@ import 'tailwindcss/tailwind.css';
 
 const TypewriterText = () => {
   return (
-    <div className="flex flex-col md:grid md:grid-cols-2 items-center md:items-start justify-start min-h-screen pt-10 md:pt-20">
-      <span className="text-gray-700 text-4xl justify-self-end mr-2">Shaping</span>
-      <div className="text-green-600 text-4xl justify-self-start">
+    <div className="flex items-center justify-center space-x-2 pt-4 text-4xl">
+      <span className="text-gray-700">Shaping</span>
+      <div className="text-green-600">
         <Typewriter
           options={{
             strings: ['Environment', 'Future', 'Policy'],
             autoStart: true,
-            loop: true
+            loop: true,
           }}
         />
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import GlobeComponent from '../components/ThreeComponents/GlobeComponent/GlobeComponent';
+import TypewriterText from '../components/TypewriterText';
 import '../styles/globals.css';
 
 const HomePage = () => {
   return (
-    <div className="w-full h-screen ">
+    <div className="relative w-full h-screen">
+      <div className="absolute left-1/2 -translate-x-1/2 top-4">
+        <TypewriterText />
+      </div>
       <ErrorBoundary>
         <GlobeComponent />
       </ErrorBoundary>


### PR DESCRIPTION
## Summary
- adjust TypewriterText layout for single line display
- overlay TypewriterText above globe on homepage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd8bd8edc833191d1cc632642bd4c