### PR TITLE
Update hero section with typewriter effect

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Typewriter from 'typewriter-effect';
+
+const Hero: React.FC = () => {
+  return (
+    <section className="w-full h-screen flex items-center justify-center bg-gradient-to-b from-white to-green-50">
+      <div className="bg-white bg-opacity-80 rounded-lg shadow-lg p-8 text-center max-w-xl">
+        <h1 className="font-mono text-3xl md:text-4xl text-gray-800 mb-4 h-12">
+          <Typewriter
+            options={{
+              strings: ['Forest Restoration', 'Precision Farming', 'Carbon Reduction'],
+              autoStart: true,
+              loop: true,
+              pauseFor: 2000,
+            } as any}
+          />
+        </h1>
+        <p className="text-gray-700 text-lg md:text-xl mb-6">
+          Advancing climate solutions through certified carbon credits
+        </p>
+        <button className="border border-green-600 text-green-600 px-6 py-2 rounded hover:bg-green-600 hover:text-white transition-colors">
+          Join Our Mission
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default Hero;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -25,7 +25,7 @@ const Navbar: React.FC = () => {
   );
 
   return (
-    <nav className="bg-white text-gray-700 shadow-md p-4 w-full">
+    <nav className="bg-white text-gray-700 shadow-md p-4 w-full fixed top-0 left-0 z-50">
       <div className="container mx-auto flex justify-between items-center">
         {/* Logo and Text */}
         <Link href="/" legacyBehavior>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import ErrorBoundary from '../components/ErrorBoundary';
-import GlobeComponent from '../components/ThreeComponents/GlobeComponent/GlobeComponent';
 import '../styles/globals.css';
+import Hero from '../components/Hero';
 
 const HomePage = () => {
   return (
-    <div className="w-full h-screen ">
-      <ErrorBoundary>
-        <GlobeComponent />
-      </ErrorBoundary>
+    <div className="w-full h-screen">
+      <Hero />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add new `Hero` component with typewriter effect cycling climate phrases
- remove 3D globe from home page and use new hero
- make navbar fixed so it stays visible while scrolling

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e5ee833d8833184b5ee31433ae35b