### PR TITLE
Add hero section and sticky navbar

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Typewriter from 'typewriter-effect';
+import Link from 'next/link';
+
+const Hero: React.FC = () => {
+  return (
+    <section className="relative flex items-center justify-center bg-white min-h-screen pt-16">
+      <div className="relative mx-4 p-8 md:p-16 bg-white/60 backdrop-blur-lg rounded-xl shadow-lg text-center flex flex-col items-center">
+        <h1 className="font-mono font-bold text-3xl sm:text-5xl text-gray-800 mb-4">
+          <Typewriter
+            options={{
+              strings: ['Article6 Revives Forests', 'Article6 Powers Precision Farming', 'Article6 Reduces Carbon'],
+              autoStart: true,
+              loop: true,
+              pauseFor: 2000,
+            }}
+          />
+        </h1>
+        <p className="text-gray-700 mb-6">
+          Advancing climate solutions through certified carbon credits
+        </p>
+        <Link href="/contact" legacyBehavior>
+          <a className="border-2 border-green-600 text-green-600 rounded-full px-6 py-2 hover:bg-green-600 hover:text-white transition-colors">
+            Join Our Mission
+          </a>
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default Hero;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -25,7 +25,7 @@ const Navbar: React.FC = () => {
   );
 
   return (
-    <nav className="bg-white text-gray-700 shadow-md p-4 w-full">
+    <nav className="bg-white text-gray-700 shadow-md p-4 w-full sticky top-0 z-50">
       <div className="container mx-auto flex justify-between items-center">
         {/* Logo and Text */}
         <Link href="/" legacyBehavior>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import ErrorBoundary from '../components/ErrorBoundary';
-import GlobeComponent from '../components/ThreeComponents/GlobeComponent/GlobeComponent';
+import Hero from '../components/Hero';
 import '../styles/globals.css';
 
 const HomePage = () => {
   return (
-    <div className="w-full h-screen ">
-      <ErrorBoundary>
-        <GlobeComponent />
-      </ErrorBoundary>
+    <div className="w-full">
+      <Hero />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create `Hero` component with typewriter text and CTA button
- make navbar sticky to top
- replace globe homepage with new hero content

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6840946483319c713ed80b4b6653