### PR TITLE
Replace 3D globe with hero text

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -6,31 +6,34 @@ const Hero: React.FC = () => {
     <div className="flex items-center justify-center min-h-screen bg-white">
       <div className="backdrop-blur-lg bg-white/50 p-8 md:p-12 rounded-xl text-center shadow-lg">
         <h1 className="font-mono text-3xl md:text-4xl text-gray-800 min-h-[2.5rem]">
-          <Typewriter
-            onInit={(typewriter) => {
-              typewriter
-                .pauseFor(500)
-                .typeString('Article6 Revives Forests')
-                .pauseFor(2000)
-                .deleteAll()
-                .typeString('Article6 Powers Precision Farming')
-                .pauseFor(2000)
-                .deleteAll()
-                .typeString('Article6 Reduces Carbon')
-                .pauseFor(2000)
-                .deleteAll()
-                .start();
-            }}
-            options={{
-              autoStart: true,
-              loop: true,
-            }}
-          />
+          <span>Article6 </span>
+          <span className="inline-block">
+            <Typewriter
+              onInit={(typewriter) => {
+                typewriter
+                  .pauseFor(500)
+                  .typeString('Revives Forests')
+                  .pauseFor(2000)
+                  .deleteAll()
+                  .typeString('Powers Precision Farming')
+                  .pauseFor(2000)
+                  .deleteAll()
+                  .typeString('Reduces Carbon')
+                  .pauseFor(2000)
+                  .deleteAll()
+                  .start();
+              }}
+              options={{
+                autoStart: true,
+                loop: true,
+              }}
+            />
+          </span>
         </h1>
         <p className="mt-4 text-gray-700">
           Advancing climate solutions through certified carbon credits
         </p>
-        <button className="mt-6 px-6 py-3 rounded-full border border-green-600 text-green-600 hover:bg-green-600 hover:text-white transition-colors">
+        <button className="mt-6 px-6 py-3 rounded-full text-green-600 hover:bg-green-600 hover:text-white transition-colors">
           Join Our Mission
         </button>
       </div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Typewriter from 'typewriter-effect';
+
+const Hero: React.FC = () => {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-white">
+      <div className="backdrop-blur-lg bg-white/50 p-8 md:p-12 rounded-xl text-center shadow-lg">
+        <h1 className="font-mono text-3xl md:text-4xl text-gray-800 min-h-[2.5rem]">
+          <Typewriter
+            options={{
+              strings: [
+                'Article6 Revives Forests',
+                'Article6 Powers Precision Farming',
+                'Article6 Reduces Carbon'
+              ],
+              autoStart: true,
+              loop: true,
+              pauseFor: 2000
+            }}
+          />
+        </h1>
+        <p className="mt-4 text-gray-700">
+          Advancing climate solutions through certified carbon credits
+        </p>
+        <button className="mt-6 px-6 py-3 rounded-full border border-green-600 text-green-600 hover:bg-green-600 hover:text-white transition-colors">
+          Join Our Mission
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Hero;

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -7,15 +7,23 @@ const Hero: React.FC = () => {
       <div className="backdrop-blur-lg bg-white/50 p-8 md:p-12 rounded-xl text-center shadow-lg">
         <h1 className="font-mono text-3xl md:text-4xl text-gray-800 min-h-[2.5rem]">
           <Typewriter
+            onInit={(typewriter) => {
+              typewriter
+                .pauseFor(500)
+                .typeString('Article6 Revives Forests')
+                .pauseFor(2000)
+                .deleteAll()
+                .typeString('Article6 Powers Precision Farming')
+                .pauseFor(2000)
+                .deleteAll()
+                .typeString('Article6 Reduces Carbon')
+                .pauseFor(2000)
+                .deleteAll()
+                .start();
+            }}
             options={{
-              strings: [
-                'Article6 Revives Forests',
-                'Article6 Powers Precision Farming',
-                'Article6 Reduces Carbon'
-              ],
               autoStart: true,
               loop: true,
-              pauseFor: 2000
             }}
           />
         </h1>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import Hero from '../components/Hero';
-import '../styles/globals.css';
+import React from "react";
+import Hero from "../components/Hero";
 
 const HomePage = () => {
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import ErrorBoundary from '../components/ErrorBoundary';
-import GlobeComponent from '../components/ThreeComponents/GlobeComponent/GlobeComponent';
+import Hero from '../components/Hero';
 import '../styles/globals.css';
 
 const HomePage = () => {
   return (
-    <div className="w-full h-screen ">
-      <ErrorBoundary>
-        <GlobeComponent />
-      </ErrorBoundary>
+    <div className="w-full h-screen">
+      <Hero />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add new Hero component with glass panel and Typewriter.js text
- show Hero on the homepage instead of the 3D globe

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ea2b8939083318f822d50c5285c31