### PR TITLE
Add video-based hero section

### DIFF
--- a/components/GlobeSection.tsx
+++ b/components/GlobeSection.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ErrorBoundary from './ErrorBoundary';
+import GlobeComponent from './ThreeComponents/GlobeComponent/GlobeComponent';
+
+const GlobeSection: React.FC = () => (
+  <div className="w-full h-screen">
+    <ErrorBoundary>
+      <GlobeComponent />
+    </ErrorBoundary>
+  </div>
+);
+
+export default GlobeSection;

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -5,17 +5,17 @@ const HeroSection: React.FC = () => {
     <div className="relative w-full h-screen overflow-hidden">
       <video
         className="absolute inset-0 w-full h-full object-cover"
-        src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
+        src="https://ik.imagekit.io/tzublgy5d/drone1.mp4?updatedAt=1754575398687"
         autoPlay
         loop
         muted
         playsInline
       />
       <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-6xl md:text-8xl font-extrabold tracking-tight drop-shadow-xl">
+        <h1 className="text-white text-7xl md:text-9xl font-black tracking-tight drop-shadow-2xl">
           Pioneering <span className="text-green-500">Carbon Solutions</span>
         </h1>
-        <p className="mt-8 text-white/90 text-xl md:text-2xl font-medium tracking-wide">
+        <p className="mt-8 text-white/90 text-xl md:text-2xl font-semibold tracking-wide">
           Technology for a sustainable future
         </p>
       </div>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -5,7 +5,7 @@ const HeroSection: React.FC = () => {
     <div className="relative w-full h-screen overflow-hidden">
       <video
         className="absolute inset-0 w-full h-full object-cover"
-        src="https://ik.imagekit.io/tzublgy5d/Article6/hero.mp4?updatedAt=1754586460660"
+        src="https://ik.imagekit.io/tzublgy5d/Article6/hero360.mp4?updatedAt=1754587990038"
         autoPlay
         loop
         muted

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const HeroSection: React.FC = () => {
+  return (
+    <div className="relative w-full h-screen overflow-hidden">
+      <video
+        className="absolute inset-0 w-full h-full object-cover"
+        src="https://ik.imagekit.io/tzublgy5d/drone1.mp4?updatedAt=1754575398687"
+        autoPlay
+        loop
+        muted
+        playsInline
+      />
+      <div className="absolute inset-0 bg-black/50 flex flex-col items-center justify-center text-center px-4">
+        <h1 className="text-white text-5xl md:text-7xl font-bold">
+          Pioneering <span className="text-green-600">Carbon Solutions</span>
+        </h1>
+        <p className="mt-4 text-white text-xl md:text-2xl">
+          Technology for a sustainable future
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default HeroSection;
+

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -5,17 +5,17 @@ const HeroSection: React.FC = () => {
     <div className="relative w-full h-screen overflow-hidden">
       <video
         className="absolute inset-0 w-full h-full object-cover"
-        src="https://ik.imagekit.io/tzublgy5d/drone1.mp4?updatedAt=1754575398687"
+        src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
         autoPlay
         loop
         muted
         playsInline
       />
       <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-7xl md:text-9xl font-black tracking-tight drop-shadow-2xl">
+        <h1 className="text-white text-5xl md:text-7xl font-bold tracking-tight drop-shadow-xl">
           Pioneering <span className="text-green-500">Carbon Solutions</span>
         </h1>
-        <p className="mt-8 text-white/90 text-xl md:text-2xl font-semibold tracking-wide">
+        <p className="mt-6 text-white/90 text-lg md:text-xl font-semibold tracking-wide">
           Technology for a sustainable future
         </p>
       </div>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -5,17 +5,17 @@ const HeroSection: React.FC = () => {
     <div className="relative w-full h-screen overflow-hidden">
       <video
         className="absolute inset-0 w-full h-full object-cover"
-        src="https://ik.imagekit.io/tzublgy5d/drone1.mp4?updatedAt=1754575398687"
+        src="https://ik.imagekit.io/tzublgy5d/Article6/hero.mp4?updatedAt=1754586460660"
         autoPlay
         loop
         muted
         playsInline
       />
-      <div className="absolute inset-0 bg-black/50 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-5xl md:text-7xl font-bold">
-          Pioneering <span className="text-green-600">Carbon Solutions</span>
+      <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
+        <h1 className="text-white text-5xl md:text-7xl font-light tracking-tight drop-shadow-lg">
+          Pioneering <span className="text-green-500 font-medium">Carbon Solutions</span>
         </h1>
-        <p className="mt-4 text-white text-xl md:text-2xl">
+        <p className="mt-6 text-white/80 text-lg md:text-xl">
           Technology for a sustainable future
         </p>
       </div>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -12,10 +12,10 @@ const HeroSection: React.FC = () => {
         playsInline
       />
       <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-5xl md:text-7xl font-light tracking-tight drop-shadow-lg">
-          Pioneering <span className="text-green-500 font-medium">Carbon Solutions</span>
+        <h1 className="text-white text-6xl md:text-8xl font-extrabold tracking-tight drop-shadow-xl">
+          Pioneering <span className="text-green-500">Carbon Solutions</span>
         </h1>
-        <p className="mt-6 text-white/80 text-lg md:text-xl">
+        <p className="mt-8 text-white/90 text-xl md:text-2xl font-medium tracking-wide">
           Technology for a sustainable future
         </p>
       </div>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -5,7 +5,7 @@ const HeroSection: React.FC = () => {
     <div className="relative w-full h-screen overflow-hidden">
       <video
         className="absolute inset-0 w-full h-full object-cover"
-        src="https://ik.imagekit.io/tzublgy5d/Article6/hero360.mp4?updatedAt=1754587990038"
+        src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
         autoPlay
         loop
         muted

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -12,10 +12,10 @@ const HeroSection: React.FC = () => {
         playsInline
       />
       <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-5xl md:text-7xl font-bold tracking-tight drop-shadow-xl">
+        <h1 className="text-white text-4xl md:text-5xl font-semibold tracking-tight drop-shadow-xl">
           Pioneering <span className="text-green-500">Carbon Solutions</span>
         </h1>
-        <p className="mt-6 text-white/90 text-lg md:text-xl font-semibold tracking-wide">
+        <p className="mt-6 text-white/90 text-base md:text-lg font-medium tracking-wide">
           Technology for a sustainable future
         </p>
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 import GlobeComponent from '../components/ThreeComponents/GlobeComponent/GlobeComponent';
+import HeroSection from '../components/HeroSection';
 import '../styles/globals.css';
 
 const HomePage = () => {
   return (
-    <div className="w-full h-screen ">
-      <ErrorBoundary>
-        <GlobeComponent />
-      </ErrorBoundary>
+    <div className="w-full">
+      <HeroSection />
+      <div className="w-full h-screen">
+        <ErrorBoundary>
+          <GlobeComponent />
+        </ErrorBoundary>
+      </div>
     </div>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import ErrorBoundary from '../components/ErrorBoundary';
-import GlobeComponent from '../components/ThreeComponents/GlobeComponent/GlobeComponent';
 import HeroSection from '../components/HeroSection';
 import '../styles/globals.css';
 
@@ -8,11 +6,6 @@ const HomePage = () => {
   return (
     <div className="w-full">
       <HeroSection />
-      <div className="w-full h-screen">
-        <ErrorBoundary>
-          <GlobeComponent />
-        </ErrorBoundary>
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a full-screen hero section with a looping drone video background and prominent headline
- render the new hero section on the home page before the existing globe visualization

## Testing
- `npm run lint`
- `npm run build` *(fails: Attempted import error: 'use' is not exported from 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6894b26079808331bc243fbd33e0c4a3