### PR TITLE
fix: improve mobile navbar

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { navigationLinks } from '../utils/navigation';
@@ -10,47 +10,70 @@ const Navbar: React.FC = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
   };
 
-  const renderLinks = (mobile = false) => (
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    if (isMobileMenuOpen) {
+      document.addEventListener('keydown', handleEsc);
+      document.body.classList.add('mobile-menu-open');
+    } else {
+      document.body.classList.remove('mobile-menu-open');
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEsc);
+      document.body.classList.remove('mobile-menu-open');
+    };
+  }, [isMobileMenuOpen]);
+
+  const renderLinks = (mobile = false) =>
     navigationLinks.map(link => (
       <Link key={link.href} href={link.href} legacyBehavior>
-        <a 
-          className={`hover:text-green-600 transition-colors duration-300 ease-in-out ${mobile ? 'border-b border-white py-8 text-2xl text-left px-8 w-full' : ''}`}
+        <a
+          className={`nav-link hover:text-green-400 transition-colors duration-300 ease-in-out ${mobile ? 'py-4 text-2xl text-center w-full' : ''}`}
           onClick={mobile ? toggleMobileMenu : undefined}
         >
           {link.label}
         </a>
       </Link>
-    ))
-  );
+    ));
 
   return (
-    <nav className="bg-white text-gray-700 shadow-md p-4 w-full">
-      <div className="container mx-auto flex justify-between items-center">
-        {/* Logo and Text */}
-        <Link href="/" legacyBehavior>
-          <a className="flex items-center text-lg font-bold">
-            Article<span className="text-green-600">6</span>
-          </a>
-        </Link>
+    <nav className="flex items-center justify-between min-h-14 px-4 w-full bg-transparent text-white drop-shadow-md">
+      {/* Logo and Text */}
+      <Link href="/" legacyBehavior>
+        <a className="flex items-center font-bold h-8 w-32 overflow-hidden flex-shrink-0">
+          Article<span className="text-green-600">6</span>
+        </a>
+      </Link>
 
-        {/* Desktop Navigation */}
-        <div className="hidden md:flex gap-12">
-          {renderLinks()}
-        </div>
-
-        {/* Mobile Navigation - Hamburger Icon */}
-        <div className="md:hidden">
-          <button onClick={toggleMobileMenu}>
-            <Bars3Icon className="h-6 w-6" />
-          </button>
-        </div>
+      {/* Desktop Navigation */}
+      <div className="hidden md:flex space-x-6">
+        {renderLinks()}
       </div>
 
-      {/* Mobile Navigation - Menu Overlay */}
-      <div 
-        className={`md:hidden bg-green-100 w-full h-full absolute top-0 left-0 flex flex-col justify-start pt-20 z-50 transition-transform duration-300 ease-in-out ${isMobileMenuOpen ? 'translate-y-0' : '-translate-y-full'}`}
+      {/* Mobile Navigation - Hamburger Icon */}
+      <button
+        className="md:hidden p-2 mr-2"
+        onClick={toggleMobileMenu}
+        aria-label="Open Menu"
       >
-        <button onClick={toggleMobileMenu} className="absolute top-4 right-4">
+        <Bars3Icon className="h-6 w-6" />
+      </button>
+
+      {/* Mobile Navigation - Menu Overlay */}
+      <div
+        className={`fixed inset-0 bg-white/95 text-gray-900 flex flex-col items-center justify-center z-50 transition-transform duration-300 ease-in-out md:hidden ${isMobileMenuOpen ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <button
+          onClick={toggleMobileMenu}
+          className="absolute top-4 right-4 p-2"
+          aria-label="Close Menu"
+        >
           <XMarkIcon className="h-6 w-6" />
         </button>
         {renderLinks(true)}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,6 +12,10 @@ html, body {
   overflow-y: auto; /* Allows vertical scrolling */
 }
 
+body.mobile-menu-open {
+  overflow: hidden;
+}
+
 canvas {
   display: block;
 }
@@ -44,4 +48,8 @@ canvas {
 
 .cardBack {
   transform: rotateY(180deg);
+}
+
+.nav-link {
+  @apply drop-shadow-md;
 }


### PR DESCRIPTION
## Summary
- ensure navbar flex layout on small screens
- add full-screen overlay menu with esc and scroll lock
- add drop-shadow style for navigation links

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68963ecff2bc8331b80d46c39c944191