### PR TITLE
feat: add active pipeline view

### DIFF
--- a/components/PipelineCard.tsx
+++ b/components/PipelineCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export const STATUS_COLORS: Record<string, string> = {
+  'In Discussion': 'bg-yellow-500',
+  'Pending Agreement': 'bg-orange-500',
+  'Early Engagement': 'bg-blue-500',
+  'Available': 'bg-green-500',
+};
+
+interface PipelineCardProps {
+  state: string;
+  status: string;
+  summary: string;
+}
+
+const PipelineCard: React.FC<PipelineCardProps> = ({ state, status, summary }) => {
+  const colorClass = STATUS_COLORS[status] || 'bg-gray-400';
+  return (
+    <div className="border rounded p-4 shadow-sm mb-4">
+      <h2 className="text-xl font-semibold mb-1 flex items-center">
+        <span className={`w-3 h-3 rounded-full mr-2 ${colorClass}`}></span>
+        {state}
+      </h2>
+      <p className="text-sm italic mb-2">{status}</p>
+      <p className="text-gray-700">{summary}</p>
+    </div>
+  );
+};
+
+export default PipelineCard;

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -1,9 +1,48 @@
 import React from 'react';
+import PipelineCard, { STATUS_COLORS } from '../../components/PipelineCard';
 
-const ProjectsPage = () => {
+const pipeline = [
+  { state: 'Niger', status: 'In Discussion', summary: 'Exploring AWD rice farming program' },
+  { state: 'Kwara', status: 'Pending Agreement', summary: 'Evaluating forestry + MRV solutions' },
+  { state: 'Plateau', status: 'Early Engagement', summary: 'Initial talks on reforestation initiative' },
+  { state: 'Open Slot', status: 'Available', summary: 'Partner with us to unlock carbon revenue' },
+];
+
+const ProjectsPage: React.FC = () => {
   return (
-    <div>
-      <h1>This is the Projects page</h1>
+    <div className="p-8">
+      <p className="mb-4 text-gray-600">
+        All projects shown are in various stages of development and will be updated as formal agreements are signed.
+      </p>
+      <h1 className="text-3xl font-bold mb-6">Current Pipeline</h1>
+      <div className="grid md:grid-cols-2 gap-4 mb-8">
+        {pipeline.map((proj) => (
+          <PipelineCard key={proj.state} {...proj} />
+        ))}
+      </div>
+      <div className="mb-8">
+        <h3 className="text-lg font-semibold mb-2">Status Legend</h3>
+        <ul className="space-y-1">
+          {Object.entries(STATUS_COLORS).map(([status, color]) => (
+            <li key={status} className="flex items-center">
+              <span className={`w-3 h-3 rounded-full mr-2 ${color}`}></span>
+              {status}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="w-full max-w-xl mx-auto">
+        <svg viewBox="0 0 700 500" className="w-full h-auto">
+          <path
+            d="M100 150 L200 120 L350 130 L450 110 L550 150 L580 220 L560 300 L600 360 L520 420 L400 380 L300 420 L180 400 L140 300 L100 250 Z"
+            fill="#e5e7eb"
+            stroke="#374151"
+          />
+          <circle cx="300" cy="220" r="10" fill="#F59E0B" />
+          <circle cx="240" cy="260" r="10" fill="#F97316" />
+          <circle cx="380" cy="240" r="10" fill="#3B82F6" />
+        </svg>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add PipelineCard component for state, status, and summary
- show pipeline cards, status legend, and Nigeria map on Projects page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896dc451d948331900ccacd5e7c9602