### PR TITLE
feat: add optional state gallery

### DIFF
--- a/data/states.ts
+++ b/data/states.ts
@@ -5,6 +5,7 @@ export interface StateInfo {
   status: string;
   timeline: string[];
   docs: { label: string; href: string }[];
+  images?: string[];
 }
 
 export const states: StateInfo[] = [
@@ -23,6 +24,10 @@ export const states: StateInfo[] = [
       { label: 'Proposal (Niger)', href: '/docs/niger_proposal.pdf' },
       { label: 'MOU (Niger)', href: '/docs/niger_mou.pdf' },
       { label: 'LOS (Niger)', href: '/docs/niger_los.pdf' },
+    ],
+    images: [
+      'https://ik.imagekit.io/tzublgy5d/Article6/Niger%20State/Niger%20meeting%202.jpeg',
+      'https://ik.imagekit.io/tzublgy5d/Article6/Niger%20State/Niger%20meeting.jpeg',
     ],
   },
   {

--- a/pages/states/[slug].tsx
+++ b/pages/states/[slug].tsx
@@ -60,6 +60,22 @@ const StateDetailPage: React.FC = () => {
         </div>
       </div>
 
+      {state.images && state.images.length > 0 && (
+        <div className="max-w-5xl mx-auto mt-12">
+          <h2 className="text-xl font-semibold mb-4">Gallery</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {state.images.map((src) => (
+              <img
+                key={src}
+                src={src}
+                alt="Dinner with Niger State delegation, Abuja"
+                className="w-full object-cover rounded-xl border border-gray-200"
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="flex space-x-4">
         <a
           href="https://wa.me/2349066876272"


### PR DESCRIPTION
## Summary
- add optional gallery to state pages when images are provided
- include Niger State dinner images with grid layout and styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68974ca33da88331a5dba244e7fd082d