### PR TITLE
feat: centralize state contacts and add carousel

### DIFF
--- a/components/DetailsCarousel.tsx
+++ b/components/DetailsCarousel.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+
+export default function DetailsCarousel({
+  overview,
+  progress,
+  nextSteps,
+  contacts,
+}: {
+  overview: React.ReactNode;
+  progress: React.ReactNode;
+  nextSteps: React.ReactNode;
+  contacts: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-2xl border bg-white shadow-sm">
+      <Carousel className="w-full">
+        <CarouselContent>
+          <CarouselItem className="basis-full p-6">{overview}</CarouselItem>
+          <CarouselItem className="basis-full p-6">{progress}</CarouselItem>
+          <CarouselItem className="basis-full p-6">{nextSteps}</CarouselItem>
+          <CarouselItem className="basis-full p-6">{contacts}</CarouselItem>
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+    </div>
+  );
+}
+

--- a/data/stateMeta.ts
+++ b/data/stateMeta.ts
@@ -3,3 +3,18 @@ export const stateTitles: Record<string, string> = {
   kwara: "Kwara — Renewable + Agro pilots",
   plateau: "Plateau — Highland Reforestation",
 };
+
+export const stateMeta: Record<string, { contact: string; role?: string }> = {
+  niger: {
+    contact: "Dr. Matthew Ahmed",
+    role: "Permanent Secretary, Ministry of Agriculture & Food Security",
+  },
+  kwara: {
+    contact: "Hon. Alabi Afeez",
+    role: "Commissioner of Agriculture",
+  },
+  plateau: {
+    contact: "Mr. Yakubu Nuhu",
+    role: "Special Adviser to the Governor on Carbon",
+  },
+};

--- a/data/states.ts
+++ b/data/states.ts
@@ -16,7 +16,7 @@ export const states: StateInfo[] = [
     epithet: 'The Power State',
     status: 'In Discussion',
     timeline: [
-      'Intro call with Dr. Ladan (Perm Sec’s office) – proposal discussed',
+      'Intro call with Dr. Matthew Ahmed (Perm Sec) – proposal discussed',
       'EOI, Proposal, MOU, LOS sent for review',
       'Drinks with Niger State delegation in Abuja for alignment',
     ],

--- a/pages/states/[slug].tsx
+++ b/pages/states/[slug].tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import DetailsCarousel from '@/components/DetailsCarousel';
 import GalleryCarousel from '@/components/GalleryCarousel';
 import { getStateBySlug } from '@/data/states';
+import { stateMeta } from '@/data/stateMeta';
 
 const STATUS_STYLES: Record<string, string> = {
   'In Discussion': 'bg-yellow-100 text-yellow-800',
@@ -10,10 +12,13 @@ const STATUS_STYLES: Record<string, string> = {
   'Early Engagement': 'bg-slate-100 text-slate-800',
 };
 
+const ORDER = ['niger', 'kwara', 'plateau'];
+
 const StateDetailPage: React.FC = () => {
   const router = useRouter();
   const { slug } = router.query;
-  const state = typeof slug === 'string' ? getStateBySlug(slug) : undefined;
+  const slugStr = typeof slug === 'string' ? slug : '';
+  const state = slugStr ? getStateBySlug(slugStr) : undefined;
 
   if (!state) {
     return (
@@ -26,6 +31,54 @@ const StateDetailPage: React.FC = () => {
 
   const statusClass = STATUS_STYLES[state.status] || 'bg-gray-100 text-gray-800';
   const images = state.images ?? [];
+  const meta = stateMeta[slugStr] || { contact: "" };
+
+  const overview = (
+    <section className="space-y-3">
+      <h2 className="text-xl font-semibold">Overview</h2>
+      <p className="text-sm leading-relaxed">{state.epithet}</p>
+      {images.length > 0 && <GalleryCarousel images={images} />}
+    </section>
+  );
+
+  const progress = (
+    <section className="space-y-3">
+      <h2 className="text-xl font-semibold">What we&apos;ve done so far</h2>
+      <ul className="list-disc pl-5 space-y-2 text-sm leading-relaxed">
+        {state.timeline.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+
+  const nextSteps = (
+    <section className="space-y-3">
+      <h2 className="text-xl font-semibold">Next steps</h2>
+      <ol className="list-decimal pl-5 space-y-2 text-sm leading-relaxed">
+        {state.nextSteps?.map((step) => (
+          <li key={step}>{step}</li>
+        ))}
+      </ol>
+    </section>
+  );
+
+  const contacts = (
+    <aside className="space-y-4">
+      <h2 className="text-xl font-semibold">Contacts</h2>
+      <div className="rounded-xl border bg-muted/30 p-4 space-y-2 text-sm">
+        <div>
+          <span className="font-medium">Contact:</span> {meta.contact}
+        </div>
+        {meta.role && <div className="text-muted-foreground">{meta.role}</div>}
+      </div>
+    </aside>
+  );
+
+  const idx = ORDER.indexOf(slugStr);
+  const prev = ORDER[(idx - 1 + ORDER.length) % ORDER.length];
+  const next = ORDER[(idx + 1) % ORDER.length];
+  const cap = (s: string) => s[0].toUpperCase() + s.slice(1);
 
   return (
     <>
@@ -40,98 +93,48 @@ const StateDetailPage: React.FC = () => {
         </div>
       </header>
 
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-8">
-        <div className="rounded-2xl border bg-white shadow-sm">
-          <div className="p-6 border-b">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h1 className="text-3xl font-semibold tracking-tight">{state.title}</h1>
-                <p className="text-muted-foreground mt-1">{state.epithet}</p>
-              </div>
-              <span className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${statusClass}`}>
-                {state.status}
-              </span>
-            </div>
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-8 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">{state.title}</h1>
+            <p className="text-muted-foreground mt-1">{state.epithet}</p>
           </div>
+          <span className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${statusClass}`}>
+            {state.status}
+          </span>
+        </div>
 
-          <div className="p-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <section className="lg:col-span-2 space-y-6">
-              {images.length > 0 && <GalleryCarousel images={images} />}
+        <DetailsCarousel overview={overview} progress={progress} nextSteps={nextSteps} contacts={contacts} />
 
-              <div className="space-y-3">
-                <h2 className="text-xl font-semibold">What we&apos;ve done so far</h2>
-                <ul className="list-disc pl-5 space-y-2 text-sm leading-relaxed">
-                  {state.timeline.map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-              </div>
+        <div className="px-6 pb-6 pt-3 border-t bg-gradient-to-b from-transparent to-muted/30 flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-end">
+          <Link
+            href="/country"
+            className="inline-flex items-center rounded-xl border px-4 py-2 text-sm font-medium hover:bg-accent"
+          >
+            See National Map
+          </Link>
+          <Link
+            href="/contact"
+            className="inline-flex items-center rounded-xl bg-black text-white px-4 py-2 text-sm font-medium hover:opacity-90"
+          >
+            Request Brief
+          </Link>
+        </div>
 
-              {state.nextSteps && state.nextSteps.length > 0 && (
-                <div className="space-y-3">
-                  <h2 className="text-xl font-semibold">Next steps</h2>
-                  <ol className="list-decimal pl-5 space-y-2 text-sm leading-relaxed">
-                    {state.nextSteps.map((step) => (
-                      <li key={step}>{step}</li>
-                    ))}
-                  </ol>
-                </div>
-              )}
-
-              {state.docs && state.docs.length > 0 && (
-                <div className="space-y-3">
-                  <h2 className="text-xl font-semibold">Documents shared</h2>
-                  <div className="flex flex-wrap gap-2">
-                    {state.docs.map((doc) => (
-                      <a
-                        key={doc.href}
-                        href={doc.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="px-3 py-1 border rounded-full text-sm"
-                      >
-                        {doc.label}
-                      </a>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </section>
-
-            <aside className="lg:col-span-1">
-              <div className="rounded-xl border bg-muted/30 p-4 sticky top-20 space-y-4">
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Contacts</p>
-                  <div className="mt-2 space-y-1 text-sm">
-                    <div>Perm Sec: Dr. Ladan</div>
-                  </div>
-                </div>
-                <div className="border-t pt-4">
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Focus Areas</p>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <span className="px-2 py-1 rounded-lg border text-xs">Rice (AWD)</span>
-                    <span className="px-2 py-1 rounded-lg border text-xs">Forestry MRV</span>
-                  </div>
-                </div>
-              </div>
-            </aside>
-          </div>
-
-          <div className="px-6 pb-6 pt-3 border-t bg-gradient-to-b from-transparent to-muted/30">
-            <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-end">
-              <Link
-                href="/country"
-                className="inline-flex items-center rounded-xl border px-4 py-2 text-sm font-medium hover:bg-accent"
-              >
-                See National Map
-              </Link>
-              <Link
-                href="/contact"
-                className="inline-flex items-center rounded-xl bg-black text-white px-4 py-2 text-sm font-medium hover:opacity-90"
-              >
-                Request Brief
-              </Link>
-            </div>
+        <div className="px-6 pb-6 pt-3 border-t bg-gradient-to-b from-transparent to-muted/30">
+          <div className="flex items-center justify-between">
+            <Link
+              href={`/states/${prev}`}
+              className="inline-flex items-center rounded-xl border px-4 py-2 text-sm hover:bg-accent"
+            >
+              ← {cap(prev)}
+            </Link>
+            <Link
+              href={`/states/${next}`}
+              className="inline-flex items-center rounded-xl bg-black text-white px-4 py-2 text-sm hover:opacity-90"
+            >
+              {cap(next)} →
+            </Link>
           </div>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- centralize per-state contacts in `stateMeta`
- fix Niger timeline copy and use mapped contacts
- add swipeable DetailsCarousel with prev/next navigation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68987edbd2ac8331b0186532e1a26c34