### PR TITLE
feat: add state meta and carousel navigation

### DIFF
--- a/components/StateDetailsCard.tsx
+++ b/components/StateDetailsCard.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+import GalleryCarousel from "@/components/GalleryCarousel";
+import { getStateBySlug } from "@/data/states";
+import { stateMeta } from "@/data/stateMeta";
+
+const STATUS_STYLES: Record<string, string> = {
+  "In Discussion": "bg-yellow-100 text-yellow-800",
+  "Pending Agreement": "bg-blue-100 text-blue-800",
+  "Early Engagement": "bg-slate-100 text-slate-800",
+};
+
+export default function StateDetailsCard({ slug }: { slug: string }) {
+  const state = getStateBySlug(slug);
+  const meta = stateMeta[slug];
+
+  if (!state || !meta) return null;
+
+  const statusClass = STATUS_STYLES[state.status] || "bg-gray-100 text-gray-800";
+  const images = state.images ?? [];
+
+  return (
+    <div className="rounded-2xl border bg-white shadow-sm">
+      <div className="p-6 border-b">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">{meta.title}</h1>
+            <p className="text-muted-foreground mt-1">{meta.subtitle}</p>
+          </div>
+          <span className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${statusClass}`}>
+            {state.status}
+          </span>
+        </div>
+      </div>
+
+      <div className="p-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <section className="lg:col-span-2 space-y-6">
+          {images.length > 0 && <GalleryCarousel images={images} />}
+
+          <div className="space-y-3">
+            <h2 className="text-xl font-semibold">What we&apos;ve done so far</h2>
+            <ul className="list-disc pl-5 space-y-2 text-sm leading-relaxed">
+              {state.timeline.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+
+          {state.nextSteps && state.nextSteps.length > 0 && (
+            <div className="space-y-3">
+              <h2 className="text-xl font-semibold">Next steps</h2>
+              <ol className="list-decimal pl-5 space-y-2 text-sm leading-relaxed">
+                {state.nextSteps.map((step) => (
+                  <li key={step}>{step}</li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          {state.docs && state.docs.length > 0 && (
+            <div className="space-y-3">
+              <h2 className="text-xl font-semibold">Documents shared</h2>
+              <div className="flex flex-wrap gap-2">
+                {state.docs.map((doc) => (
+                  <a
+                    key={doc.href}
+                    href={doc.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="px-3 py-1 border rounded-full text-sm"
+                  >
+                    {doc.label}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
+
+        <aside className="lg:col-span-1">
+          <div className="rounded-xl border bg-muted/30 p-4 sticky top-20 space-y-4">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Contacts</p>
+              <div className="mt-2 space-y-1 text-sm">
+                <div>{meta.contact}</div>
+                {meta.role && <div className="text-xs text-muted-foreground">{meta.role}</div>}
+              </div>
+            </div>
+            <div className="border-t pt-4">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Focus Areas</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                <span className="px-2 py-1 rounded-lg border text-xs">Rice (AWD)</span>
+                <span className="px-2 py-1 rounded-lg border text-xs">Forestry MRV</span>
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <div className="px-6 pb-6 pt-3 border-t bg-gradient-to-b from-transparent to-muted/30">
+        <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-end">
+          <Link
+            href="/country"
+            className="inline-flex items-center rounded-xl border px-4 py-2 text-sm font-medium hover:bg-accent"
+          >
+            See National Map
+          </Link>
+          <Link
+            href="/contact"
+            className="inline-flex items-center rounded-xl bg-black text-white px-4 py-2 text-sm font-medium hover:opacity-90"
+          >
+            Request Brief
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/StateDetailsCarousel.tsx
+++ b/components/StateDetailsCarousel.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import StateDetailsCard from "@/components/StateDetailsCard";
+
+export default function StateDetailsCarousel({ states, startIndex = 0 }: { states: string[]; startIndex?: number }) {
+  return (
+    <Carousel className="w-full" opts={{ startIndex }}>
+      <CarouselContent>
+        {states.map((slug) => (
+          <CarouselItem key={slug} className="basis-full">
+            <StateDetailsCard slug={slug} />
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious className="md:top-1/2 md:-translate-y-1/2 top-auto bottom-2 translate-y-0" />
+      <CarouselNext className="md:top-1/2 md:-translate-y-1/2 top-auto bottom-2 translate-y-0" />
+    </Carousel>
+  );
+}
+

--- a/data/stateMeta.ts
+++ b/data/stateMeta.ts
@@ -1,3 +1,27 @@
+export const stateMeta: Record<string, { contact: string; role?: string; slug: string; title: string; subtitle: string }> = {
+  niger: {
+    slug: "niger",
+    title: "Niger State",
+    subtitle: "The Power State",
+    contact: "Dr. Matthew Ahmed",
+    role: "Permanent Secretary, Ministry of Agriculture & Food Security",
+  },
+  kwara: {
+    slug: "kwara",
+    title: "Kwara State",
+    subtitle: "The State of Harmony",
+    contact: "Hon. Alabi Afeez",
+    role: "Commissioner of Agriculture",
+  },
+  plateau: {
+    slug: "plateau",
+    title: "Plateau State",
+    subtitle: "The Home of Peace and Tourism",
+    contact: "Mr. Yakubu Nuhu",
+    role: "Special Adviser to the Governor on Carbon",
+  },
+};
+
 export const stateTitles: Record<string, string> = {
   niger: "Niger — Rice & Forestry MRV",
   kwara: "Kwara — Renewable + Agro pilots",

--- a/data/states.ts
+++ b/data/states.ts
@@ -16,7 +16,7 @@ export const states: StateInfo[] = [
     epithet: 'The Power State',
     status: 'In Discussion',
     timeline: [
-      'Intro call with Dr. Ladan (Perm Sec’s office) – proposal discussed',
+      'Intro call with Dr. Matthew Ahmed (Perm Sec) – proposal discussed',
       'EOI, Proposal, MOU, LOS sent for review',
       'Drinks with Niger State delegation in Abuja for alignment',
     ],

--- a/pages/states/[slug].tsx
+++ b/pages/states/[slug].tsx
@@ -1,143 +1,20 @@
-import React from 'react';
-import { useRouter } from 'next/router';
-import Link from 'next/link';
-import GalleryCarousel from '@/components/GalleryCarousel';
-import { getStateBySlug } from '@/data/states';
+import { useRouter } from "next/router";
+import StateDetailsCarousel from "@/components/StateDetailsCarousel";
 
-const STATUS_STYLES: Record<string, string> = {
-  'In Discussion': 'bg-yellow-100 text-yellow-800',
-  'Pending Agreement': 'bg-blue-100 text-blue-800',
-  'Early Engagement': 'bg-slate-100 text-slate-800',
-};
+const ORDER = ["niger", "kwara", "plateau"];
 
-const StateDetailPage: React.FC = () => {
+export default function StatePage() {
   const router = useRouter();
   const { slug } = router.query;
-  const state = typeof slug === 'string' ? getStateBySlug(slug) : undefined;
-
-  if (!state) {
-    return (
-      <div className="p-8">
-        <h1 className="text-2xl font-bold mb-2">State Not Found</h1>
-        <p className="text-gray-600">Details for this state are not available.</p>
-      </div>
-    );
-  }
-
-  const statusClass = STATUS_STYLES[state.status] || 'bg-gray-100 text-gray-800';
-  const images = state.images ?? [];
+  const startIndex = typeof slug === "string" ? ORDER.indexOf(slug) : 0;
 
   return (
-    <>
-      <header className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-6">
-        <div className="flex items-center md:justify-between justify-start gap-3">
-          <Link
-            href="/projects"
-            className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
-          >
-            <span className="mr-2">←</span> Back to Projects
-          </Link>
-        </div>
-      </header>
-
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-8">
-        <div className="rounded-2xl border bg-white shadow-sm">
-          <div className="p-6 border-b">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h1 className="text-3xl font-semibold tracking-tight">{state.title}</h1>
-                <p className="text-muted-foreground mt-1">{state.epithet}</p>
-              </div>
-              <span className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${statusClass}`}>
-                {state.status}
-              </span>
-            </div>
-          </div>
-
-          <div className="p-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <section className="lg:col-span-2 space-y-6">
-              {images.length > 0 && <GalleryCarousel images={images} />}
-
-              <div className="space-y-3">
-                <h2 className="text-xl font-semibold">What we&apos;ve done so far</h2>
-                <ul className="list-disc pl-5 space-y-2 text-sm leading-relaxed">
-                  {state.timeline.map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-              </div>
-
-              {state.nextSteps && state.nextSteps.length > 0 && (
-                <div className="space-y-3">
-                  <h2 className="text-xl font-semibold">Next steps</h2>
-                  <ol className="list-decimal pl-5 space-y-2 text-sm leading-relaxed">
-                    {state.nextSteps.map((step) => (
-                      <li key={step}>{step}</li>
-                    ))}
-                  </ol>
-                </div>
-              )}
-
-              {state.docs && state.docs.length > 0 && (
-                <div className="space-y-3">
-                  <h2 className="text-xl font-semibold">Documents shared</h2>
-                  <div className="flex flex-wrap gap-2">
-                    {state.docs.map((doc) => (
-                      <a
-                        key={doc.href}
-                        href={doc.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="px-3 py-1 border rounded-full text-sm"
-                      >
-                        {doc.label}
-                      </a>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </section>
-
-            <aside className="lg:col-span-1">
-              <div className="rounded-xl border bg-muted/30 p-4 sticky top-20 space-y-4">
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Contacts</p>
-                  <div className="mt-2 space-y-1 text-sm">
-                    <div>Perm Sec: Dr. Ladan</div>
-                  </div>
-                </div>
-                <div className="border-t pt-4">
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Focus Areas</p>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <span className="px-2 py-1 rounded-lg border text-xs">Rice (AWD)</span>
-                    <span className="px-2 py-1 rounded-lg border text-xs">Forestry MRV</span>
-                  </div>
-                </div>
-              </div>
-            </aside>
-          </div>
-
-          <div className="px-6 pb-6 pt-3 border-t bg-gradient-to-b from-transparent to-muted/30">
-            <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-end">
-              <Link
-                href="/country"
-                className="inline-flex items-center rounded-xl border px-4 py-2 text-sm font-medium hover:bg-accent"
-              >
-                See National Map
-              </Link>
-              <Link
-                href="/contact"
-                className="inline-flex items-center rounded-xl bg-black text-white px-4 py-2 text-sm font-medium hover:opacity-90"
-              >
-                Request Brief
-              </Link>
-            </div>
-          </div>
-        </div>
-      </main>
-    </>
+    <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-8">
+      <StateDetailsCarousel
+        states={ORDER}
+        startIndex={startIndex >= 0 ? startIndex : 0}
+      />
+    </main>
   );
-};
-
-export default StateDetailPage;
+}
 


### PR DESCRIPTION
## Summary
- centralize state metadata with contacts and display titles/subtitles
- render state details through carousel with per-state cards
- fix Niger timeline contact name

## Testing
- `pnpm add embla-carousel-react`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689882b4ed108331a6d80003ee1ce065