### PR TITLE
feat: add interactive country page

### DIFF
--- a/data/country.ts
+++ b/data/country.ts
@@ -1,0 +1,57 @@
+export const SLUGS = [
+  "abia",
+  "adamawa",
+  "akwa-ibom",
+  "anambra",
+  "bauchi",
+  "bayelsa",
+  "benue",
+  "borno",
+  "cross-river",
+  "delta",
+  "ebonyi",
+  "edo",
+  "ekiti",
+  "enugu",
+  "fct",
+  "gombe",
+  "imo",
+  "jigawa",
+  "kaduna",
+  "kano",
+  "katsina",
+  "kebbi",
+  "kogi",
+  "kwara",
+  "lagos",
+  "nasarawa",
+  "niger",
+  "ogun",
+  "ondo",
+  "osun",
+  "oyo",
+  "plateau",
+  "rivers",
+  "sokoto",
+  "taraba",
+  "yobe",
+  "zamfara",
+] as const;
+
+export const STATES = Object.fromEntries(
+  SLUGS.map((s) => [s, { name: toTitle(s) }])
+) as Record<string, { name: string }>;
+
+export const ACTIVE = ["niger", "kwara", "plateau"] as string[];
+export const PIPELINE = ["kebbi", "benue"] as string[];
+
+export const META: Record<string, { tag?: string }> = {
+  niger: { tag: "Rice & Forestry MRV" },
+  kwara: { tag: "Renewable + Agro pilots" },
+  plateau: { tag: "Highland Reforestation" },
+  // add as needed
+};
+
+export function toTitle(slug: string) {
+  return slug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}


### PR DESCRIPTION
## Summary
- add canonical country metadata and activity tags
- create responsive country overview page with search, filters, and CTAs
- enhance Nigeria SVG map with hover states, links, and keyboard focus

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898ad839ecc8331802a3ffd8cb56849