### PR TITLE
fix(about-us): use /about-us route, add /about redirect, ship modern glass About page

### DIFF
--- a/components/ui/GlassCard.tsx
+++ b/components/ui/GlassCard.tsx
@@ -2,7 +2,9 @@ import { ReactNode } from 'react';
 
 export default function GlassCard({ children, className = '' }: { children: ReactNode; className?: string }) {
   return (
-    <div className={`rounded-3xl bg-white/10 backdrop-blur-xl ${className}`}>
+    <div
+      className={`rounded-2xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md ${className}`}
+    >
       {children}
     </div>
   );

--- a/components/ui/GlassCard.tsx
+++ b/components/ui/GlassCard.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 export default function GlassCard({ children, className = '' }: { children: ReactNode; className?: string }) {
   return (
-    <div className={`rounded-3xl border border-white/40 bg-white/10 backdrop-blur-xl shadow-[0_10px_40px_-10px_rgba(0,0,0,0.25)] ${className}`}>
+    <div className={`rounded-3xl bg-white/10 backdrop-blur-xl ${className}`}>
       {children}
     </div>
   );

--- a/components/ui/GlassCard.tsx
+++ b/components/ui/GlassCard.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+export default function GlassCard({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={`rounded-3xl border border-white/40 bg-white/10 backdrop-blur-xl shadow-[0_10px_40px_-10px_rgba(0,0,0,0.25)] ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/components/ui/SectionTitle.tsx
+++ b/components/ui/SectionTitle.tsx
@@ -1,0 +1,11 @@
+export default function SectionTitle({
+  kicker, title, subtitle,
+}: { kicker?: string; title: string; subtitle?: string }) {
+  return (
+    <header className="mb-6">
+      {kicker && <div className="text-xs uppercase tracking-widest text-gray-500">{kicker}</div>}
+      <h2 className="text-2xl md:text-3xl font-semibold tracking-tight">{title}</h2>
+      {subtitle && <p className="mt-2 text-gray-600 max-w-prose">{subtitle}</p>}
+    </header>
+  );
+}

--- a/components/ui/ik.ts
+++ b/components/ui/ik.ts
@@ -1,0 +1,2 @@
+export const ik = (src: string, tr = 'tr=w-1600,q-80,fo-auto'): string =>
+  src.endsWith('?') ? `${src}${tr}` : src.includes('?') ? `${src}&${tr}` : `${src}?${tr}`;

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    images: {
-      domains: ['ik.imagekit.io'],
-    },
-    // ... other configurations you might have
-  };
-  
-  module.exports = nextConfig;
+  images: {
+    domains: ['ik.imagekit.io'],
+    remotePatterns: [
+      { protocol: 'https', hostname: 'ik.imagekit.io', pathname: '/tzublgy5d/**' },
+    ],
+  },
+  async redirects() {
+    return [
+      { source: '/about', destination: '/about-us', permanent: true },
+    ];
+  },
+  // ... other configurations you might have
+};
+
+module.exports = nextConfig;
   

--- a/pages/about-us/index.tsx
+++ b/pages/about-us/index.tsx
@@ -27,25 +27,25 @@ export default function AboutUs() {
           <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-black/20 to-white/0" />
         </div>
         <div className="relative mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-20 md:py-28">
-          <div className="max-w-3xl">
-            <GlassCard className="p-6 md:p-8">
-              <h1 className="text-3xl md:text-5xl font-semibold tracking-tight text-white">
-                From commitment to verified impact.
-              </h1>
-              <p className="mt-4 text-white/90">
-                Article6 matches nation states with the right technologies and delivery teams to run climate programs
-                that are measurable, auditable, and built to last.
-              </p>
-              <div className="mt-6">
-                <Link
-                  href="/contact"
-                  className="inline-flex items-center rounded-2xl bg-black text-white px-5 py-3 shadow hover:opacity-90"
-                >
-                  Join the Waitlist
-                </Link>
-              </div>
-            </GlassCard>
-          </div>
+            <div className="max-w-3xl">
+              <GlassCard className="p-6 md:p-8 border-0 shadow-none hover:shadow-none bg-white/15 backdrop-blur-xl">
+                <h1 className="text-3xl md:text-5xl font-semibold tracking-tight text-white">
+                  From commitment to verified impact.
+                </h1>
+                <p className="mt-4 text-white/90">
+                  Article6 matches nation states with the right technologies and delivery teams to run climate programs
+                  that are measurable, auditable, and built to last.
+                </p>
+                <div className="mt-6">
+                  <Link
+                    href="/contact"
+                    className="inline-flex items-center rounded-2xl bg-black text-white px-5 py-3 shadow hover:opacity-90"
+                  >
+                    Join the Waitlist
+                  </Link>
+                </div>
+              </GlassCard>
+            </div>
         </div>
       </section>
 

--- a/pages/about-us/index.tsx
+++ b/pages/about-us/index.tsx
@@ -1,55 +1,164 @@
-// pages/about/index.tsx
-import React from 'react';
+import Image from "next/image";
+import Link from "next/link";
+import GlassCard from "@/components/ui/GlassCard";
+import SectionTitle from "@/components/ui/SectionTitle";
+import { ik } from "@/components/ui/ik";
 
-const AboutUsPage = () => {
-  return (
-    <div className="container mx-auto py-16 px-6 max-w-4xl"> {/* Consistent margins and width */}
-      {/* Header Section */}
-      <div className="text-center mb-16">
-        <h1 className="text-6xl font-extrabold mb-6 text-green-700">
-          About Us
-        </h1>
-        <p className="text-lg text-gray-700">
-          At Article<span className="text-green-600">6</span>, we are committed to harnessing the power of technology and innovation to drive sustainability and environmental conservation. Our mission is to create a better future by developing and implementing solutions that make a real-world impact.
-        </p>
-      </div>
-
-      {/* Mission Section */}
-      <div className="mb-16">
-        <h2 className="text-4xl font-semibold mb-4 text-green-700">Our Mission</h2>
-        <p className="text-lg text-gray-700">
-          Our mission is to empower communities and industries to adopt sustainable practices. We focus on projects that address climate change, promote renewable energy, and support responsible resource management. Through our collaborative approach, we aim to make a lasting difference in the world.
-        </p>
-      </div>
-
-      {/* Values Section */}
-      <div className="mb-16">
-        <h2 className="text-4xl font-semibold mb-4 text-green-700">Our Values</h2>
-        <ul className="list-disc list-inside text-lg text-gray-700">
-          <li>Innovation: We believe in the power of creativity and new ideas to solve global challenges.</li>
-          <li>Sustainability: Our work is guided by the principles of environmental stewardship and long-term impact.</li>
-          <li>Collaboration: We value partnerships and teamwork as essential components of success.</li>
-          <li>Integrity: We are committed to transparency, accountability, and ethical practices in all that we do.</li>
-        </ul>
-      </div>
-
-      {/* Team Section */}
-      <div className="mb-16">
-        <h2 className="text-4xl font-semibold mb-4 text-green-700">Meet Our Team</h2>
-        <p className="text-lg text-gray-700">
-          Our team is composed of experts from diverse backgrounds, including environmental science, technology, and project management. We are passionate about driving change and are dedicated to advancing the principles of sustainable development.
-        </p>
-      </div>
-
-      {/* Vision Section */}
-      <div className="mb-16">
-        <h2 className="text-4xl font-semibold mb-4 text-green-700">Our Vision</h2>
-        <p className="text-lg text-gray-700">
-          Our vision is a world where sustainable practices are the norm, and where technology plays a key role in addressing environmental challenges. We strive to be at the forefront of this movement, leading by example and inspiring others to join us on this journey.
-        </p>
-      </div>
-    </div>
-  );
+const IMGS = {
+  hero: "https://ik.imagekit.io/tzublgy5d/Article6/About%20us/HeroAboutUs.png?",
+  match: "https://ik.imagekit.io/tzublgy5d/Article6/About%20us/Technology%20matching.png?",
+  mrv: "https://ik.imagekit.io/tzublgy5d/Article6/About%20us/mrrv%20as%20a%20service.png?",
+  enable: "https://ik.imagekit.io/tzublgy5d/Article6/About%20us/project%20enablement.png?",
 };
 
-export default AboutUsPage;
+export default function AboutUs() {
+  return (
+    <main className="relative">
+      {/* HERO */}
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0">
+          <Image
+            src={ik(IMGS.hero, 'tr=w-2400,q-80,fo-auto')}
+            alt="Aerial Earth view with subtle grid overlay"
+            fill
+            priority
+            className="object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-black/20 to-white/0" />
+        </div>
+        <div className="relative mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-20 md:py-28">
+          <div className="max-w-3xl">
+            <GlassCard className="p-6 md:p-8 bg-white/15">
+              <h1 className="text-3xl md:text-5xl font-semibold tracking-tight text-white">
+                From commitment to verified impact.
+              </h1>
+              <p className="mt-4 text-white/90">
+                Article6 matches nation states with the right technologies and delivery teams to run climate programs
+                that are measurable, auditable, and built to last.
+              </p>
+              <div className="mt-6">
+                <Link
+                  href="/contact"
+                  className="inline-flex items-center rounded-2xl bg-black text-white px-5 py-3 shadow hover:opacity-90"
+                >
+                  Join the Waitlist
+                </Link>
+              </div>
+            </GlassCard>
+          </div>
+        </div>
+      </section>
+
+      {/* WHAT WE DO */}
+      <section className="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-12 md:py-16">
+        <SectionTitle
+          title="What we do"
+          subtitle="We integrate proven climate technologies and delivery partners into one working stack."
+        />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {/* Technology matching */}
+          <GlassCard className="overflow-hidden">
+            <div className="aspect-video relative">
+              <Image src={ik(IMGS.match)} alt="Global technology network visualization" fill className="object-cover" />
+            </div>
+            <div className="p-5">
+              <h3 className="font-medium text-lg">Technology matching</h3>
+              <p className="mt-2 text-sm text-gray-700">
+                We source and vet remote sensing, MRV platforms, open‑source tools, and field systems—and assemble them into one stack.
+              </p>
+            </div>
+          </GlassCard>
+
+          {/* MRV‑AI as a service */}
+          <GlassCard className="overflow-hidden">
+            <div className="aspect-video relative">
+              <Image src={ik(IMGS.mrv)} alt="Real landscapes with subtle data overlays" fill className="object-cover" />
+            </div>
+            <div className="p-5">
+              <h3 className="font-medium text-lg">MRV‑AI as a service</h3>
+              <p className="mt-2 text-sm text-gray-700">
+                Continuous measurement, reporting, and verification for forestry, rice (AWD), ERW, and EWD—ready for external review.
+              </p>
+            </div>
+          </GlassCard>
+
+          {/* Program enablement */}
+          <GlassCard className="overflow-hidden">
+            <div className="aspect-video relative">
+              <Image src={ik(IMGS.enable)} alt="On‑site teams delivering climate projects" fill className="object-cover" />
+            </div>
+            <div className="p-5">
+              <h3 className="font-medium text-lg">Program enablement</h3>
+              <p className="mt-2 text-sm text-gray-700">
+                We line up implementation partners, playbooks, and training to execute at state and national scale.
+              </p>
+            </div>
+          </GlassCard>
+        </div>
+      </section>
+
+      {/* WHY IT MATTERS */}
+      <section className="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-12 md:py-16">
+        <SectionTitle title="Why it matters" />
+        <GlassCard className="p-6 md:p-8">
+          <p className="text-gray-800">
+            Ambitious plans fail without evidence. Article6 closes the gap between policy and proof—so governments can
+            unlock climate finance, report with confidence, and show progress the public can trust.
+          </p>
+        </GlassCard>
+      </section>
+
+      {/* HOW WE WORK */}
+      <section className="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-12 md:py-16">
+        <SectionTitle title="How we work" subtitle="A clear, auditable path from assessment to verification." />
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          {[
+            { t: "Assess", d: "Map objectives, data readiness, and timelines." },
+            { t: "Match", d: "Select the right tech and delivery partners, no vendor bias." },
+            { t: "Deliver", d: "Stand up the stack, train teams, integrate workflows." },
+            { t: "Verify", d: "Produce audit‑ready MRV and maintain continuous reporting." },
+          ].map((s, i) => (
+            <GlassCard key={i} className="p-5 h-full">
+              <div className="text-sm uppercase tracking-wide text-gray-500">
+                {String(i + 1).padStart(2, "0")}
+              </div>
+              <h4 className="mt-2 font-medium">{s.t}</h4>
+              <p className="mt-1 text-sm text-gray-700">{s.d}</p>
+            </GlassCard>
+          ))}
+        </div>
+      </section>
+
+      {/* VALUES */}
+      <section className="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-12 md:py-16">
+        <SectionTitle title="How we build" />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {[
+            { t: "Open and interoperable", d: "We prefer open standards and open‑source components so states keep control of their data." },
+            { t: "Local capacity first", d: "We design for handover and run‑by‑locals, not black boxes." },
+            { t: "Security by design", d: "Access controls, audit logs, and region options where required." },
+            { t: "Evidence over hype", d: "Clear methods, transparent assumptions, and citations where it counts." },
+          ].map((v, i) => (
+            <GlassCard key={i} className="p-5">
+              <h4 className="font-medium">{v.t}</h4>
+              <p className="mt-1 text-sm text-gray-700">{v.d}</p>
+            </GlassCard>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 pb-16">
+        <GlassCard className="p-8 text-center bg-white/20">
+          <h3 className="text-xl md:text-2xl font-semibold">Join the waitlist</h3>
+          <p className="mt-2 text-sm text-gray-800">
+            We’re onboarding a limited number of state programs. If you’re ready to turn plans into verifiable results, we’re ready to help.
+          </p>
+          <Link href="/contact" className="inline-flex items-center mt-5 rounded-2xl bg-black text-white px-6 py-3 shadow hover:opacity-90">
+            Get on the Waitlist
+          </Link>
+        </GlassCard>
+      </section>
+    </main>
+  );
+}

--- a/pages/about-us/index.tsx
+++ b/pages/about-us/index.tsx
@@ -28,7 +28,7 @@ export default function AboutUs() {
         </div>
         <div className="relative mx-auto max-w-6xl px-4 md:px-6 lg:px-8 py-20 md:py-28">
           <div className="max-w-3xl">
-            <GlassCard className="p-6 md:p-8 bg-white/15">
+            <GlassCard className="p-6 md:p-8">
               <h1 className="text-3xl md:text-5xl font-semibold tracking-tight text-white">
                 From commitment to verified impact.
               </h1>
@@ -149,7 +149,7 @@ export default function AboutUs() {
 
       {/* CTA */}
       <section className="mx-auto max-w-6xl px-4 md:px-6 lg:px-8 pb-16">
-        <GlassCard className="p-8 text-center bg-white/20">
+        <GlassCard className="p-8 text-center">
           <h3 className="text-xl md:text-2xl font-semibold">Join the waitlist</h3>
           <p className="mt-2 text-sm text-gray-800">
             We’re onboarding a limited number of state programs. If you’re ready to turn plans into verifiable results, we’re ready to help.


### PR DESCRIPTION
## Summary
- redirect `/about` to `/about-us`
- allow ImageKit `tzublgy5d` assets via `next/image`
- add GlassCard, SectionTitle, and `ik` helper
- rebuild `/about-us` with glassy UI components

## Testing
- `pnpm lint`
- `pnpm build`
- `curl -I http://localhost:3000/about-us`
- `curl -I http://localhost:3000/about`

------
https://chatgpt.com/codex/tasks/task_e_689a37f62c688331b51bc2210e15e109