### PR TITLE
feat: update hero with glass card overlay

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -22,11 +22,14 @@ const HeroSection: React.FC = () => {
       <div className="relative h-full w-full flex items-center justify-center px-4">
         <div className="w-full max-w-3xl mx-auto">
           <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
-            <h1 className="text-white text-3xl md:text-5xl font-semibold tracking-tight">
-              <span className="opacity-90">The carbon stack for </span>
+            <h1 className="text-white text-3xl md:text-5xl font-semibold tracking-tight leading-tight inline-flex flex-nowrap items-baseline md:whitespace-nowrap">
+              <span className="opacity-90">The carbon stack for&nbsp;</span>
               <RotatingPhrase
                 phrases={["governments", "treasuries", "climate teams"]}
-                className="text-green-400"
+                className="text-green-400 align-baseline"
+                typeSpeedMs={60}
+                deleteSpeedMs={40}
+                holdMs={2000}
                 reducedMotionFallback="governments"
               />
             </h1>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -27,9 +27,11 @@ const HeroSection: React.FC = () => {
               <RotatingPhrase
                 phrases={["governments", "treasuries", "climate teams"]}
                 className="text-green-400 align-baseline"
-                typeSpeedMs={60}
-                deleteSpeedMs={40}
-                holdMs={2000}
+                typeSpeedMs={90}
+                deleteSpeedMs={60}
+                holdMs={2600}
+                preTypeDelayMs={400}
+                postDeleteDelayMs={650}
                 reducedMotionFallback="governments"
               />
             </h1>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -18,23 +18,43 @@ const HeroSection: React.FC = () => {
           loop
           muted
           playsInline
+          preload="metadata"
         />
       ) : (
         <div className="absolute inset-0 w-full h-full bg-black" />
       )}
-      <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl">
-          Pioneering <span className="text-green-500">Carbon Solutions</span>
-        </h1>
-        <p className="mt-6 text-white/90 text-lg md:text-xl font-medium tracking-wide">
-          Technology for a sustainable future
-        </p>
-        <Link
-          href="/contact"
-          className="mt-10 inline-block rounded-md bg-white px-6 py-3 text-base font-semibold text-green-500 shadow-lg transition hover:bg-green-50"
-        >
-          Contact Us
-        </Link>
+      <div className="absolute inset-0">
+        <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/20 to-transparent pointer-events-none" />
+        <div className="relative h-full w-full flex items-center justify-center px-4">
+          <div className="w-full max-w-3xl mx-auto">
+            <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
+              <h1 className="text-white text-4xl md:text-5xl font-semibold tracking-tight">
+                Operationalizing <span className="text-green-500">Article&nbsp;6</span> for Nigerian States
+              </h1>
+
+              <p className="mt-4 text-white/90 text-base md:text-lg leading-relaxed">
+                MRV-AI and turnkey execution—from LOS → MOU → <span className="font-semibold">FERA</span>—to unlock climate finance under Articles 6.2, 6.4, and 6.8.
+              </p>
+
+              <div className="mt-6 flex flex-col sm:flex-row gap-3">
+                <Link
+                  href="/contact#briefing"
+                  className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-black bg-white/90 hover:bg-white transition"
+                  aria-label="Book a 20-minute Government Briefing"
+                >
+                  Book a 20-min Government Briefing
+                </Link>
+                <Link
+                  href="/mrv-ai#waitlist"
+                  className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-white/90 border border-white/30 hover:bg-white/10 transition"
+                  aria-label="Join the MRV-AI Waitlist"
+                >
+                  Join the MRV-AI Waitlist
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Link from "next/link";
-import RotatingPhrase from "@/components/RotatingPhrase";
 
 const HeroSection: React.FC = () => {
   return (
@@ -15,38 +14,34 @@ const HeroSection: React.FC = () => {
         playsInline
         preload="metadata"
       />
-      {/* subtle gradient for contrast */}
+      {/* subtle gradient to improve contrast behind the glass card */}
       <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/20 to-transparent pointer-events-none" />
 
-      {/* Fixed glass card container */}
       <div className="relative h-full w-full flex items-center justify-center px-4">
         <div className="w-full max-w-3xl mx-auto">
           <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
-            <h1 className="text-white text-3xl md:text-5xl font-semibold tracking-tight leading-tight inline-flex flex-nowrap items-baseline md:whitespace-nowrap">
-              <span className="opacity-90">The carbon stack for&nbsp;</span>
-              <RotatingPhrase
-                phrases={["governments", "treasuries", "climate teams"]}
-                className="text-green-400 align-baseline"
-                typeSpeedMs={90}
-                deleteSpeedMs={60}
-                holdMs={2600}
-                preTypeDelayMs={400}
-                postDeleteDelayMs={650}
-                reducedMotionFallback="governments"
-              />
+            <h1 className="text-white text-4xl md:text-5xl font-semibold tracking-tight">
+              Operationalizing <span className="text-green-500">Article&nbsp;6</span> for Nigerian States
             </h1>
 
             <p className="mt-4 text-white/90 text-base md:text-lg leading-relaxed">
-              AI-powered MRV to measure, verify, and trade carbon under Article 6.2 / 6.4.
+              MRV-AI and turnkey execution—from LOS → MOU → <span className="font-semibold">FERA</span>—to unlock climate finance under Articles 6.2, 6.4, and 6.8.
             </p>
 
-            <div className="mt-6">
+            <div className="mt-6 flex flex-col sm:flex-row gap-3">
               <Link
                 href="/contact#briefing"
                 className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-black bg-white/90 hover:bg-white transition"
                 aria-label="Book a 20-minute Government Briefing"
               >
-                Book a Government Briefing
+                Book a 20-min Government Briefing
+              </Link>
+              <Link
+                href="/mrv-ai#waitlist"
+                className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-white/90 border border-white/30 hover:bg-white/10 transition"
+                aria-label="Join the MRV-AI Waitlist"
+              >
+                Join the MRV-AI Waitlist
               </Link>
             </div>
           </div>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,57 +1,48 @@
-import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
+import React from "react";
+import Link from "next/link";
+import RotatingPhrase from "@/components/RotatingPhrase";
 
 const HeroSection: React.FC = () => {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
   return (
     <div className="relative w-full h-screen overflow-hidden">
-      {isClient ? (
-        <video
-          className="absolute inset-0 w-full h-full object-cover"
-          src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
-          autoPlay
-          loop
-          muted
-          playsInline
-          preload="metadata"
-        />
-      ) : (
-        <div className="absolute inset-0 w-full h-full bg-black" />
-      )}
-      <div className="absolute inset-0">
-        <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/20 to-transparent pointer-events-none" />
-        <div className="relative h-full w-full flex items-center justify-center px-4">
-          <div className="w-full max-w-3xl mx-auto">
-            <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
-              <h1 className="text-white text-4xl md:text-5xl font-semibold tracking-tight">
-                Operationalizing <span className="text-green-500">Article&nbsp;6</span> for Nigerian States
-              </h1>
+      {/* KEEP existing video element exactly (src/attrs unchanged) */}
+      <video
+        className="absolute inset-0 w-full h-full object-cover"
+        src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
+        autoPlay
+        loop
+        muted
+        playsInline
+        preload="metadata"
+      />
+      {/* subtle gradient for contrast */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/20 to-transparent pointer-events-none" />
 
-              <p className="mt-4 text-white/90 text-base md:text-lg leading-relaxed">
-                MRV-AI and turnkey execution—from LOS → MOU → <span className="font-semibold">FERA</span>—to unlock climate finance under Articles 6.2, 6.4, and 6.8.
-              </p>
+      {/* Fixed glass card container */}
+      <div className="relative h-full w-full flex items-center justify-center px-4">
+        <div className="w-full max-w-3xl mx-auto">
+          <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
+            <h1 className="text-white text-3xl md:text-5xl font-semibold tracking-tight">
+              <span className="opacity-90">The carbon stack for </span>
+              <RotatingPhrase
+                phrases={["governments", "treasuries", "climate teams"]}
+                className="text-green-400"
+                reducedMotionFallback="governments"
+              />
+            </h1>
 
-              <div className="mt-6 flex flex-col sm:flex-row gap-3">
-                <Link
-                  href="/contact#briefing"
-                  className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-black bg-white/90 hover:bg-white transition"
-                  aria-label="Book a 20-minute Government Briefing"
-                >
-                  Book a 20-min Government Briefing
-                </Link>
-                <Link
-                  href="/mrv-ai#waitlist"
-                  className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-white/90 border border-white/30 hover:bg-white/10 transition"
-                  aria-label="Join the MRV-AI Waitlist"
-                >
-                  Join the MRV-AI Waitlist
-                </Link>
-              </div>
+            <p className="mt-4 text-white/90 text-base md:text-lg leading-relaxed">
+              AI-powered MRV to measure, verify, and trade carbon under Article 6.2 / 6.4.
+            </p>
+
+            <div className="mt-6">
+              <Link
+                href="/contact#briefing"
+                className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-black bg-white/90 hover:bg-white transition"
+                aria-label="Book a 20-minute Government Briefing"
+              >
+                Book a Government Briefing
+              </Link>
             </div>
           </div>
         </div>
@@ -59,5 +50,4 @@ const HeroSection: React.FC = () => {
     </div>
   );
 };
-
 export default HeroSection;

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -12,9 +12,9 @@ type RotatingPhraseProps = {
 export default function RotatingPhrase({
   phrases,
   className = "",
-  typeSpeedMs = 40,
-  deleteSpeedMs = 30,
-  holdMs = 1400,
+  typeSpeedMs = 60,
+  deleteSpeedMs = 40,
+  holdMs = 2000,
   reducedMotionFallback = ""
 }: RotatingPhraseProps) {
   const [display, setDisplay] = useState("");

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+type RotatingPhraseProps = {
+  phrases: string[];              // e.g., ["governments", "treasuries", "climate teams"]
+  className?: string;             // tailwind for the visible text
+  typeSpeedMs?: number;           // typing speed per char
+  deleteSpeedMs?: number;         // delete speed per char
+  holdMs?: number;                // hold time at full word
+  reducedMotionFallback?: string; // shown if prefers-reduced-motion: reduce
+};
+
+export default function RotatingPhrase({
+  phrases,
+  className = "",
+  typeSpeedMs = 40,
+  deleteSpeedMs = 30,
+  holdMs = 1400,
+  reducedMotionFallback = ""
+}: RotatingPhraseProps) {
+  const [display, setDisplay] = useState("");
+  const [phraseIdx, setPhraseIdx] = useState(0);
+  const [phase, setPhase] = useState<"typing"|"holding"|"deleting">("typing");
+  const [maxWidth, setMaxWidth] = useState<number>(0);
+  const measureRef = useRef<HTMLDivElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const prefersReduced = typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+
+  const list = useMemo(() => phrases.filter(Boolean), [phrases]);
+
+  // Measure widest phrase (using same font classes)
+  useEffect(() => {
+    function measure() {
+      if (!measureRef.current) return;
+      let widest = 0;
+      const children = Array.from(measureRef.current.children) as HTMLElement[];
+      for (const el of children) widest = Math.max(widest, el.offsetWidth);
+      setMaxWidth(widest);
+    }
+    // wait for fonts if supported
+    // @ts-ignore
+    const ready = (document.fonts?.ready as Promise<void>) ?? Promise.resolve();
+    ready.then(() => requestAnimationFrame(measure));
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [list]);
+
+  // Typewriter loop (no layout shift because container width is fixed)
+  useEffect(() => {
+    if (prefersReduced) return; // handled by fallback render
+    const current = list[phraseIdx % list.length] ?? "";
+    let timeout: number | null = null;
+
+    const step = () => {
+      if (phase === "typing") {
+        if (display.length < current.length) {
+          setDisplay(current.slice(0, display.length + 1));
+          timeout = window.setTimeout(() => rafRef.current = requestAnimationFrame(step), typeSpeedMs);
+        } else {
+          setPhase("holding");
+          timeout = window.setTimeout(() => rafRef.current = requestAnimationFrame(step), holdMs);
+        }
+      } else if (phase === "holding") {
+        setPhase("deleting");
+        timeout = window.setTimeout(() => rafRef.current = requestAnimationFrame(step), deleteSpeedMs);
+      } else {
+        if (display.length > 0) {
+          setDisplay(current.slice(0, display.length - 1));
+          timeout = window.setTimeout(() => rafRef.current = requestAnimationFrame(step), deleteSpeedMs);
+        } else {
+          setPhraseIdx((i) => (i + 1) % list.length);
+          setPhase("typing");
+          timeout = window.setTimeout(() => rafRef.current = requestAnimationFrame(step), typeSpeedMs);
+        }
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(step);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [display, phase, phraseIdx, list, typeSpeedMs, deleteSpeedMs, holdMs, prefersReduced]);
+
+  // Fixed-width inline block prevents re-centering
+  const fixedStyle = maxWidth ? { width: `${maxWidth}px` } : undefined;
+
+  // If user prefers reduced motion, render static fallback
+  if (prefersReduced && reducedMotionFallback) {
+    return <span className={className}>{reducedMotionFallback}</span>;
+  }
+
+  return (
+    <>
+      {/* Offscreen measurement block */}
+      <div ref={measureRef} className={`${className} absolute -z-10 invisible top-0 left-0 whitespace-nowrap`}>
+        {list.map((p, i) => (
+          <span key={i} className="inline-block px-0">{p}</span>
+        ))}
+      </div>
+
+      {/* Visible fixed-width container; aria-hidden to avoid repeated announcements */}
+      <span className={`inline-block whitespace-nowrap align-baseline ${className}`} style={fixedStyle} aria-hidden="true">
+        {display}
+      </span>
+
+      {/* Screen-reader only stable label (won't spam SR with changes) */}
+      <span className="sr-only">{list[0] ?? "governments"}</span>
+    </>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ const HomePage = () => {
   return (
     <div className="w-full">
       <HeroSection />
+      <main className="max-w-6xl mx-auto p-6 space-y-6"></main>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace dark overlay with centered glass card and gradient for readability
- add MRV-AI and FERA messaging with briefing and waitlist CTAs
- ensure homepage uses standard container shell

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689af947237c8331a826f6a99c4884b2