### PR TITLE
Hero: fresh rotator (readable cadence, no layout shift), fixed glass

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -27,10 +27,10 @@ export default function HeroSection() {
               <RotatingPhrase
                 phrases={["governments", "treasuries", "climate teams"]}
                 className="text-green-400 align-baseline"
-                typeSpeedMs={100}
-                deleteSpeedMs={70}
+                typeSpeedMs={150}
+                deleteSpeedMs={90}
                 holdMs={3000}
-                preTypeDelayMs={500}
+                preTypeDelayMs={1500}
                 postDeleteDelayMs={700}
                 reducedMotionFallback="governments"
               />

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -27,8 +27,8 @@ export default function HeroSection() {
               <RotatingPhrase
                 phrases={["governments", "treasuries", "climate teams"]}
                 className="text-green-400 align-baseline"
-                typeSpeedMs={150}
-                deleteSpeedMs={90}
+                typeSpeedMs={200}
+                deleteSpeedMs={120}
                 holdMs={3000}
                 preTypeDelayMs={1500}
                 postDeleteDelayMs={700}

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,43 +1,58 @@
-import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
+import React from "react";
+import Link from "next/link";
+import RotatingPhrase from "@/components/RotatingPhrase";
 
-const HeroSection: React.FC = () => {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
+export default function HeroSection() {
   return (
     <div className="relative w-full h-screen overflow-hidden">
-      {isClient ? (
-        <video
-          className="absolute inset-0 w-full h-full object-cover"
-          src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
-          autoPlay
-          loop
-          muted
-          playsInline
-        />
-      ) : (
-        <div className="absolute inset-0 w-full h-full bg-black" />
-      )}
-      <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl">
-          Pioneering <span className="text-green-500">Carbon Solutions</span>
-        </h1>
-        <p className="mt-6 text-white/90 text-lg md:text-xl font-medium tracking-wide">
-          Technology for a sustainable future
-        </p>
-        <Link
-          href="/contact"
-          className="mt-10 inline-block rounded-md bg-white px-6 py-3 text-base font-semibold text-green-500 shadow-lg transition hover:bg-green-50"
-        >
-          Contact Us
-        </Link>
+      {/* KEEP your existing video src/attrs */}
+      <video
+        className="absolute inset-0 w-full h-full object-cover"
+        src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
+        autoPlay
+        loop
+        muted
+        playsInline
+        preload="metadata"
+      />
+      {/* subtle gradient for contrast */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/20 to-transparent pointer-events-none" />
+
+      {/* fixed glass card */}
+      <div className="relative h-full w-full flex items-center justify-center px-4">
+        <div className="w-full max-w-3xl mx-auto">
+          <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
+            <h1 className="text-white text-3xl md:text-5xl font-semibold tracking-tight leading-tight inline-flex flex-nowrap items-baseline md:whitespace-nowrap">
+              <span className="opacity-90">The carbon stack for&nbsp;</span>
+              <RotatingPhrase
+                phrases={["governments", "treasuries", "climate teams"]}
+                className="text-green-400 align-baseline"
+                typeSpeedMs={100}
+                deleteSpeedMs={70}
+                holdMs={3000}
+                preTypeDelayMs={500}
+                postDeleteDelayMs={700}
+                reducedMotionFallback="governments"
+              />
+            </h1>
+
+            <p className="mt-4 text-white/90 text-base md:text-lg leading-relaxed">
+              AI-powered MRV to measure, verify, and trade carbon under Article 6.2 / 6.4.
+            </p>
+
+            <div className="mt-6">
+              <Link
+                href="/contact#briefing"
+                className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-black bg-white/90 hover:bg-white transition"
+                aria-label="Book a 20-minute Government Briefing"
+              >
+                Book a Government Briefing
+              </Link>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );
-};
+}
 
-export default HeroSection;

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -3,8 +3,8 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 type RotatingPhraseProps = {
   phrases: string[];              // e.g. ["governments","treasuries","climate teams"]
   className?: string;
-  typeSpeedMs?: number;           // default 150 (calm ~7 chars/sec)
-  deleteSpeedMs?: number;         // default 90  (delete ~11 chars/sec)
+  typeSpeedMs?: number;           // default 200 (calm ~5 chars/sec)
+  deleteSpeedMs?: number;         // default 120 (delete ~8 chars/sec)
   holdMs?: number;                // default 3000 (≈3s on full word)
   preTypeDelayMs?: number;        // default 1500 (pause before next word)
   postDeleteDelayMs?: number;     // default 700  (pause after clearing)
@@ -14,8 +14,8 @@ type RotatingPhraseProps = {
 export default function RotatingPhrase({
   phrases,
   className = "",
-  typeSpeedMs = 150,
-  deleteSpeedMs = 90,
+  typeSpeedMs = 200,
+  deleteSpeedMs = 120,
   holdMs = 3000,
   preTypeDelayMs = 1500,
   postDeleteDelayMs = 700,

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -3,10 +3,10 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 type RotatingPhraseProps = {
   phrases: string[];              // e.g. ["governments","treasuries","climate teams"]
   className?: string;
-  typeSpeedMs?: number;           // default 100 (readable)
-  deleteSpeedMs?: number;         // default 70  (readable)
+  typeSpeedMs?: number;           // default 150 (calm ~7 chars/sec)
+  deleteSpeedMs?: number;         // default 90  (delete ~11 chars/sec)
   holdMs?: number;                // default 3000 (≈3s on full word)
-  preTypeDelayMs?: number;        // default 500  (pause before next word)
+  preTypeDelayMs?: number;        // default 1500 (pause before next word)
   postDeleteDelayMs?: number;     // default 700  (pause after clearing)
   reducedMotionFallback?: string; // if user prefers reduced motion
 };
@@ -14,10 +14,10 @@ type RotatingPhraseProps = {
 export default function RotatingPhrase({
   phrases,
   className = "",
-  typeSpeedMs = 100,
-  deleteSpeedMs = 70,
+  typeSpeedMs = 150,
+  deleteSpeedMs = 90,
   holdMs = 3000,
-  preTypeDelayMs = 500,
+  preTypeDelayMs = 1500,
   postDeleteDelayMs = 700,
   reducedMotionFallback = ""
 }: RotatingPhraseProps) {
@@ -80,13 +80,13 @@ export default function RotatingPhrase({
             rafRef.current = requestAnimationFrame(step);
           }, deleteSpeedMs);
         } else {
-          // pause after deletion, then advance & pause before typing
+          // Finished deleting: short pause, then wait preTypeDelayMs before typing
           timeout = window.setTimeout(() => {
             setPhraseIdx((i) => (i + 1) % list.length);
             window.setTimeout(() => {
               setPhase("typing");
               rafRef.current = requestAnimationFrame(step);
-            }, preTypeDelayMs);
+            }, preTypeDelayMs); // << this is the gap before the new word
           }, postDeleteDelayMs);
         }
       }

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+type RotatingPhraseProps = {
+  phrases: string[];              // e.g. ["governments","treasuries","climate teams"]
+  className?: string;
+  typeSpeedMs?: number;           // default 100 (readable)
+  deleteSpeedMs?: number;         // default 70  (readable)
+  holdMs?: number;                // default 3000 (≈3s on full word)
+  preTypeDelayMs?: number;        // default 500  (pause before next word)
+  postDeleteDelayMs?: number;     // default 700  (pause after clearing)
+  reducedMotionFallback?: string; // if user prefers reduced motion
+};
+
+export default function RotatingPhrase({
+  phrases,
+  className = "",
+  typeSpeedMs = 100,
+  deleteSpeedMs = 70,
+  holdMs = 3000,
+  preTypeDelayMs = 500,
+  postDeleteDelayMs = 700,
+  reducedMotionFallback = ""
+}: RotatingPhraseProps) {
+  const [display, setDisplay] = useState("");
+  const [phraseIdx, setPhraseIdx] = useState(0);
+  const [phase, setPhase] = useState<"typing"|"holding"|"deleting">("typing");
+  const [maxWidth, setMaxWidth] = useState<number>(0);
+  const measureRef = useRef<HTMLDivElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const list = useMemo(() => phrases.filter(Boolean), [phrases]);
+  const prefersReduced =
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+
+  // Measure widest phrase with the same styles to lock width (prevents layout shift)
+  useEffect(() => {
+    const measure = () => {
+      if (!measureRef.current) return;
+      let widest = 0;
+      const kids = Array.from(measureRef.current.children) as HTMLElement[];
+      for (const el of kids) widest = Math.max(widest, el.offsetWidth);
+      setMaxWidth(widest);
+    };
+    // @ts-ignore
+    const ready = (document.fonts?.ready as Promise<void>) ?? Promise.resolve();
+    ready.then(() => requestAnimationFrame(measure));
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [list, className]);
+
+  // Typewriter loop with readable cadence + pre/post pauses
+  useEffect(() => {
+    if (prefersReduced) return;
+    let timeout: number | null = null;
+    const current = list[phraseIdx % list.length] ?? "";
+
+    const step = () => {
+      if (phase === "typing") {
+        if (display.length < current.length) {
+          setDisplay(current.slice(0, display.length + 1));
+          timeout = window.setTimeout(() => {
+            rafRef.current = requestAnimationFrame(step);
+          }, typeSpeedMs);
+        } else {
+          setPhase("holding");
+          timeout = window.setTimeout(() => {
+            rafRef.current = requestAnimationFrame(step);
+          }, holdMs);
+        }
+      } else if (phase === "holding") {
+        setPhase("deleting");
+        timeout = window.setTimeout(() => {
+          rafRef.current = requestAnimationFrame(step);
+        }, deleteSpeedMs);
+      } else {
+        if (display.length > 0) {
+          setDisplay(current.slice(0, display.length - 1));
+          timeout = window.setTimeout(() => {
+            rafRef.current = requestAnimationFrame(step);
+          }, deleteSpeedMs);
+        } else {
+          // pause after deletion, then advance & pause before typing
+          timeout = window.setTimeout(() => {
+            setPhraseIdx((i) => (i + 1) % list.length);
+            window.setTimeout(() => {
+              setPhase("typing");
+              rafRef.current = requestAnimationFrame(step);
+            }, preTypeDelayMs);
+          }, postDeleteDelayMs);
+        }
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(step);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [display, phase, phraseIdx, list, typeSpeedMs, deleteSpeedMs, holdMs, preTypeDelayMs, postDeleteDelayMs, prefersReduced]);
+
+  const fixedStyle = maxWidth ? { width: `${maxWidth}px` } : undefined;
+
+  // Reduced-motion: show a stable, non-animated word
+  if (prefersReduced && reducedMotionFallback) {
+    return <span className={className}>{reducedMotionFallback}</span>;
+  }
+
+  return (
+    <>
+      {/* invisible offscreen measurement using same className */}
+      <div ref={measureRef} className={`${className} absolute -z-10 invisible top-0 left-0 whitespace-nowrap`}>
+        {list.map((p, i) => (
+          <span key={i} className="inline-block">{p}</span>
+        ))}
+      </div>
+
+      {/* visible fixed-width span prevents re-centering */}
+      <span
+        className={`inline-block whitespace-nowrap align-baseline ${className}`}
+        style={fixedStyle}
+        aria-hidden="true"
+      >
+        {display}
+      </span>
+      {/* Screen readers get a stable label to avoid spammy announcements */}
+      <span className="sr-only">{list[0] ?? "governments"}</span>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add stable-width RotatingPhrase component with readable type/delete cadence and reduced-motion fallback
- rework hero section with glass card and rotating phrases for governments/treasuries/climate teams

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b20301d248331ab532e7e3f23034b