### PR TITLE
Hero rotator v2: readable pacing, no layout shift, StrictMode-safe

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,13 +1,47 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import Link from "next/link";
 import RotatingPhrase from "@/components/RotatingPhrase";
 
+const HERO_SRC = "https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486";
+const HERO_SRC_1P5X = "https://ik.imagekit.io/tzublgy5d/Article6/hero480_1p5x.mp4";
+
 export default function HeroSection() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const setRate = () => {
+      try {
+        video.playbackRate = 1.5;
+      } catch {
+        // no-op
+      }
+    };
+    video.addEventListener("loadedmetadata", setRate);
+    video.addEventListener("play", setRate);
+    setRate();
+    return () => {
+      video.removeEventListener("loadedmetadata", setRate);
+      video.removeEventListener("play", setRate);
+    };
+  }, []);
+
+  const isIOS = typeof navigator !== "undefined" && /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const src = isIOS ? HERO_SRC_1P5X : HERO_SRC;
+
   return (
     <div className="relative w-full h-screen overflow-hidden">
-      <video className="absolute inset-0 w-full h-full object-cover"
-        src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
-        autoPlay loop muted playsInline preload="metadata" />
+      <video
+        ref={videoRef}
+        className="absolute inset-0 w-full h-full object-cover"
+        src={src}
+        autoPlay
+        loop
+        muted
+        playsInline
+        preload="metadata"
+      />
       <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/20 to-transparent pointer-events-none" />
       <div className="relative h-full w-full flex items-center justify-center px-4">
         <div className="w-full max-w-3xl mx-auto">

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -51,9 +51,9 @@ export default function HeroSection() {
               <RotatingPhrase
                 phrases={["governments", "treasuries", "climate teams"]}
                 className="text-green-400 align-baseline"
-                // explicit slow values (can tweak later)
-                typeSpeedMs={220}
-                deleteSpeedMs={140}
+                // tuned for human-readable speed
+                typeSpeedMs={100}
+                deleteSpeedMs={60}
                 holdMs={3200}
                 preTypeDelayMs={1200}
                 postDeleteDelayMs={800}

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,43 +1,42 @@
-import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
+import React from "react";
+import Link from "next/link";
+import RotatingPhrase from "@/components/RotatingPhrase";
 
-const HeroSection: React.FC = () => {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
+export default function HeroSection() {
   return (
     <div className="relative w-full h-screen overflow-hidden">
-      {isClient ? (
-        <video
-          className="absolute inset-0 w-full h-full object-cover"
-          src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
-          autoPlay
-          loop
-          muted
-          playsInline
-        />
-      ) : (
-        <div className="absolute inset-0 w-full h-full bg-black" />
-      )}
-      <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl">
-          Pioneering <span className="text-green-500">Carbon Solutions</span>
-        </h1>
-        <p className="mt-6 text-white/90 text-lg md:text-xl font-medium tracking-wide">
-          Technology for a sustainable future
-        </p>
-        <Link
-          href="/contact"
-          className="mt-10 inline-block rounded-md bg-white px-6 py-3 text-base font-semibold text-green-500 shadow-lg transition hover:bg-green-50"
-        >
-          Contact Us
-        </Link>
+      <video className="absolute inset-0 w-full h-full object-cover"
+        src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
+        autoPlay loop muted playsInline preload="metadata" />
+      <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/20 to-transparent pointer-events-none" />
+      <div className="relative h-full w-full flex items-center justify-center px-4">
+        <div className="w-full max-w-3xl mx-auto">
+          <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
+            <h1 className="text-white text-3xl md:text-5xl font-semibold tracking-tight leading-tight inline-flex flex-nowrap items-baseline md:whitespace-nowrap">
+              <span className="opacity-90">The carbon stack for&nbsp;</span>
+              <RotatingPhrase
+                phrases={["governments", "treasuries", "climate teams"]}
+                className="text-green-400 align-baseline"
+                // explicit slow values (can tweak later)
+                typeSpeedMs={220}
+                deleteSpeedMs={140}
+                holdMs={3200}
+                preTypeDelayMs={1200}
+                postDeleteDelayMs={800}
+                reducedMotionFallback="governments"
+              />
+            </h1>
+            <p className="mt-4 text-white/90 text-base md:text-lg leading-relaxed">
+              AI-powered MRV to measure, verify, and trade carbon under Article 6.2 / 6.4.
+            </p>
+            <div className="mt-6">
+              <Link href="/contact#briefing" className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-black bg-white/90 hover:bg-white transition">
+                Book a Government Briefing
+              </Link>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );
-};
-
-export default HeroSection;
+}

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -13,9 +13,9 @@ type Props = {
 export default function RotatingPhrase({
   phrases,
   className = "",
-  // >>> Readable keynote pacing <<<
-  typeSpeedMs = 220,          // ~4–5 chars/sec
-  deleteSpeedMs = 140,        // a bit faster than typing
+  // >>> Human-readable pacing <<<
+  typeSpeedMs = 100,          // ~10 chars/sec
+  deleteSpeedMs = 60,         // quicker erase
   holdMs = 3200,              // ≈3.2s on-screen
   preTypeDelayMs = 1200,      // 1.2s gap before next word
   postDeleteDelayMs = 800,    // 0.8s gap after clearing

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+type Phase = "typing" | "holding" | "deleting" | "gap";
+type Props = {
+  phrases: string[];
+  className?: string;
+  typeSpeedMs?: number;       // per char (typing)
+  deleteSpeedMs?: number;     // per char (deleting)
+  holdMs?: number;            // full word visible
+  preTypeDelayMs?: number;    // empty pause before next word starts typing
+  postDeleteDelayMs?: number; // empty pause right after clearing
+  reducedMotionFallback?: string;
+};
+export default function RotatingPhrase({
+  phrases,
+  className = "",
+  // >>> Readable keynote pacing <<<
+  typeSpeedMs = 220,          // ~4–5 chars/sec
+  deleteSpeedMs = 140,        // a bit faster than typing
+  holdMs = 3200,              // ≈3.2s on-screen
+  preTypeDelayMs = 1200,      // 1.2s gap before next word
+  postDeleteDelayMs = 800,    // 0.8s gap after clearing
+  reducedMotionFallback = "",
+}: Props) {
+  const list = useMemo(() => phrases.filter(Boolean), [phrases]);
+  const [text, setText] = useState(""); const [i, setI] = useState(0); const [phase, setPhase] = useState<Phase>("typing");
+  const timer = useRef<number | null>(null); const cancel = () => { if (timer.current) { clearTimeout(timer.current); timer.current = null; } };
+
+  // fixed width measurement (no layout shift)
+  const [w, setW] = useState(0); const measRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const measure = () => {
+      if (!measRef.current) return; let m = 0;
+      for (const el of Array.from(measRef.current.children) as HTMLElement[]) m = Math.max(m, el.offsetWidth);
+      setW(m);
+    };
+    // @ts-ignore
+    (document.fonts?.ready ?? Promise.resolve()).then(() => requestAnimationFrame(measure));
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [list, className]);
+
+  const prefersReduced = typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+
+  useEffect(() => {
+    if (prefersReduced) return;
+    const word = list[i % list.length] ?? "";
+    cancel();
+    const wait = (ms:number, fn:()=>void) => { timer.current = window.setTimeout(fn, ms); };
+
+    if (phase === "typing") {
+      if (text.length < word.length) wait(typeSpeedMs, () => setText(word.slice(0, text.length + 1)));
+      else wait(holdMs, () => setPhase("deleting"));
+    } else if (phase === "deleting") {
+      if (text.length > 0) wait(deleteSpeedMs, () => setText(word.slice(0, text.length - 1)));
+      else wait(postDeleteDelayMs, () => setPhase("gap"));
+    } else if (phase === "gap") {
+      wait(preTypeDelayMs, () => { setI((v) => (v + 1) % list.length); setPhase("typing"); });
+    }
+    return cancel;
+  }, [list, i, phase, text, typeSpeedMs, deleteSpeedMs, holdMs, preTypeDelayMs, postDeleteDelayMs, prefersReduced]);
+
+  const style = w ? { width: `${w}px` } : undefined;
+  if (prefersReduced && reducedMotionFallback) return <span className={className}>{reducedMotionFallback}</span>;
+
+  return (
+    <>
+      <div ref={measRef} className={`${className} absolute -z-10 invisible top-0 left-0 whitespace-nowrap`}>
+        {list.map((p, k) => <span key={k} className="inline-block">{p}</span>)}
+      </div>
+      <span className={`inline-block whitespace-nowrap align-baseline ${className}`} style={style} aria-hidden="true">
+        {text}
+      </span>
+      <span className="sr-only">{list[0] ?? "governments"}</span>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add RotatingPhrase component for typed word rotations without layout shift
- rewrite HeroSection to use RotatingPhrase with slow, readable timing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b81d2e8b48331adaa3f4ee331c306