### PR TITLE
Hero rotator v3: slow readable pacing, no-layout-shift, StrictMode-safe

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -13,7 +13,7 @@ export default function HeroSection() {
         <div className="w-full max-w-3xl mx-auto">
           <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
             <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl
-                    flex flex-wrap items-baseline justify-center gap-x-2 text-balance">
+                    flex flex-wrap items-baseline justify-center gap-x-2 text-balance w-full">
               <span>The carbon stack for</span>
               {/* Rotator sits on new line on mobile, inline from sm+ */}
               <span className="basis-full sm:basis-auto sm:ml-1">

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,43 +1,48 @@
-import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
+import React from "react";
+import Link from "next/link";
+import RotatingPhrase from "@/components/RotatingPhrase";
 
-const HeroSection: React.FC = () => {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
+export default function HeroSection() {
   return (
     <div className="relative w-full h-screen overflow-hidden">
-      {isClient ? (
-        <video
-          className="absolute inset-0 w-full h-full object-cover"
-          src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
-          autoPlay
-          loop
-          muted
-          playsInline
-        />
-      ) : (
-        <div className="absolute inset-0 w-full h-full bg-black" />
-      )}
-      <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl">
-          Pioneering <span className="text-green-500">Carbon Solutions</span>
-        </h1>
-        <p className="mt-6 text-white/90 text-lg md:text-xl font-medium tracking-wide">
-          Technology for a sustainable future
-        </p>
-        <Link
-          href="/contact"
-          className="mt-10 inline-block rounded-md bg-white px-6 py-3 text-base font-semibold text-green-500 shadow-lg transition hover:bg-green-50"
-        >
-          Contact Us
-        </Link>
+      <video className="absolute inset-0 w-full h-full object-cover"
+        src="https://ik.imagekit.io/tzublgy5d/Article6/hero480.mp4?updatedAt=1754588076486"
+        autoPlay loop muted playsInline preload="metadata" />
+      <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-black/20 to-transparent pointer-events-none" />
+      <div className="relative h-full w-full flex items-center justify-center px-4">
+        <div className="w-full max-w-3xl mx-auto">
+          <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
+            <h1 className="text-white text-3xl md:text-5xl font-semibold tracking-tight leading-tight inline-flex flex-nowrap items-baseline md:whitespace-nowrap">
+              <span className="opacity-90">The carbon stack for&nbsp;</span>
+              <RotatingPhrase
+                phrases={["governments", "treasuries", "climate teams"]}
+                className="text-green-400 align-baseline"
+                typeSpeedMs={240}
+                deleteSpeedMs={150}
+                holdMs={3400}
+                preTypeDelayMs={1200}
+                postDeleteDelayMs={800}
+                reducedMotionFallback="governments"
+              />
+            </h1>
+            <p className="mt-4 text-white/90 text-base md:text-lg leading-relaxed">
+              AI-powered MRV to measure, verify, and trade carbon under Article 6.2 / 6.4.
+            </p>
+            <div className="mt-6">
+              <Link href="/contact#briefing" className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold text-black bg-white/90 hover:bg-white transition">
+                Book a Government Briefing
+              </Link>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );
-};
+}
 
-export default HeroSection;
+// QA checklist
+// - Letters appear ~4/sec (calm).
+// - Word remains ~3.4s, then ~0.8s empty, then ~1.2s before next word begins.
+// - No layout shift; stays on one line at md+; glass card stable.
+// - Dev (StrictMode) pacing matches production (single timer cleared each effect).
+

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -12,13 +12,14 @@ export default function HeroSection() {
       <div className="relative h-full w-full flex items-center justify-center px-4">
         <div className="w-full max-w-3xl mx-auto">
           <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
-            <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl
-                    flex flex-wrap items-baseline justify-center gap-x-2 text-balance w-full">
+            <h1
+              className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl flex flex-wrap sm:flex-nowrap items-baseline justify-center gap-x-2 text-balance w-full"
+            >
               <span>The carbon stack for</span>
               {/* Rotator sits on new line on mobile, inline from sm+ */}
-              <span className="basis-full sm:basis-auto sm:ml-1">
+              <span className="basis-full sm:basis-auto">
                 <RotatingPhrase
-                  phrases={["climate teams", "state partners", "project developers"]}
+                  phrases={["governments", "treasuries", "climate teams"]}
                   mobileBlock
                   className="text-green-500"
                 />

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -12,20 +12,19 @@ export default function HeroSection() {
       <div className="relative h-full w-full flex items-center justify-center px-4">
         <div className="w-full max-w-3xl mx-auto">
           <div className="backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-2xl p-6 md:p-8">
-            <h1 className="text-white text-3xl md:text-5xl font-semibold tracking-tight leading-tight inline-flex flex-nowrap items-baseline md:whitespace-nowrap">
-              <span className="opacity-90">The carbon stack for&nbsp;</span>
-              <RotatingPhrase
-                phrases={["governments", "treasuries", "climate teams"]}
-                className="text-green-400 align-baseline"
-                typeSpeedMs={240}
-                deleteSpeedMs={150}
-                holdMs={3400}
-                preTypeDelayMs={1200}
-                postDeleteDelayMs={800}
-                reducedMotionFallback="governments"
-              />
+            <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl
+                    flex flex-wrap items-baseline justify-center gap-x-2 text-balance">
+              <span>The carbon stack for</span>
+              {/* Rotator sits on new line on mobile, inline from sm+ */}
+              <span className="basis-full sm:basis-auto sm:ml-1">
+                <RotatingPhrase
+                  phrases={["climate teams", "state partners", "project developers"]}
+                  mobileBlock
+                  className="text-green-500"
+                />
+              </span>
             </h1>
-            <p className="mt-4 text-white/90 text-base md:text-lg leading-relaxed">
+            <p className="mt-4 text-white/90 text-base md:text-lg leading-relaxed text-center text-pretty">
               AI-powered MRV to measure, verify, and trade carbon under Article 6.2 / 6.4.
             </p>
             <div className="mt-6">

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -5,7 +5,7 @@ type Phase = "typing" | "holding" | "deleting" | "gap";
 type Props = {
   phrases: string[];
   className?: string;
-  mobileBlock?: boolean; // NEW
+  mobileBlock?: boolean;
   typeSpeedMs?: number;       // per char while typing
   deleteSpeedMs?: number;     // per char while deleting
   holdMs?: number;            // full word on screen
@@ -18,73 +18,103 @@ export default function RotatingPhrase({
   phrases,
   className = "",
   mobileBlock = false,
-  // >>> Readable keynote pacing <<<
-  typeSpeedMs = 240,          // ~4 chars/sec (calm)
-  deleteSpeedMs = 150,        // a touch faster than typing
-  holdMs = 3400,              // ~3.4s fully visible
-  preTypeDelayMs = 1200,      // 1.2s gap before next word starts
-  postDeleteDelayMs = 800,    // 0.8s gap after clearing
+  typeSpeedMs = 240,
+  deleteSpeedMs = 150,
+  holdMs = 3400,
+  preTypeDelayMs = 1200,
+  postDeleteDelayMs = 800,
   reducedMotionFallback = "",
 }: Props) {
   const list = useMemo(() => phrases.filter(Boolean), [phrases]);
 
-  // compute longest phrase length for a rough min-width (prevents reflow)
-  const longest = useMemo(() => list.reduce((a, b) => (b.length > a.length ? b : a), ""), [list]);
-  const ch = Math.min(Math.max(longest.length, 10), 18); // clamp 10–18ch
-
-  // StrictMode‑safe single timer
+  // StrictMode-safe single timer
   const t = useRef<number | null>(null);
-  const clear = () => { if (t.current) { clearTimeout(t.current); t.current = null; } };
+  const clear = () => {
+    if (t.current) {
+      clearTimeout(t.current);
+      t.current = null;
+    }
+  };
 
   const [text, setText] = useState("");
   const [idx, setIdx] = useState(0);
   const [phase, setPhase] = useState<Phase>("typing");
 
-  const prefersReduced = typeof window !== "undefined" &&
+  // measure widest phrase to lock width and prevent layout shift
+  const [maxW, setMaxW] = useState(0);
+  const measRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const measure = () => {
+      if (!measRef.current) return;
+      let w = 0;
+      for (const el of Array.from(measRef.current.children) as HTMLElement[]) {
+        w = Math.max(w, el.offsetWidth);
+      }
+      setMaxW(w);
+    };
+    // @ts-ignore
+    (document.fonts?.ready ?? Promise.resolve()).then(() => requestAnimationFrame(measure));
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [list, className]);
+
+  const prefersReduced =
+    typeof window !== "undefined" &&
     window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
 
   useEffect(() => {
     if (prefersReduced) return;
     const word = list[idx % list.length] ?? "";
     clear();
-    const wait = (ms:number, fn:()=>void) => { t.current = window.setTimeout(fn, ms); };
+    const wait = (ms: number, fn: () => void) => {
+      t.current = window.setTimeout(fn, ms);
+    };
 
     if (phase === "typing") {
-      if (text.length < word.length) wait(typeSpeedMs, () => setText(word.slice(0, text.length + 1)));
+      if (text.length < word.length)
+        wait(typeSpeedMs, () => setText(word.slice(0, text.length + 1)));
       else wait(holdMs, () => setPhase("deleting"));
     } else if (phase === "deleting") {
-      if (text.length > 0) wait(deleteSpeedMs, () => setText(word.slice(0, text.length - 1)));
+      if (text.length > 0)
+        wait(deleteSpeedMs, () => setText(word.slice(0, text.length - 1)));
       else wait(postDeleteDelayMs, () => setPhase("gap"));
     } else if (phase === "gap") {
-      wait(preTypeDelayMs, () => { setIdx((i) => (i + 1) % list.length); setPhase("typing"); });
+      wait(preTypeDelayMs, () => {
+        setIdx((i) => (i + 1) % list.length);
+        setPhase("typing");
+      });
     }
     return clear;
   }, [list, idx, phase, text, typeSpeedMs, deleteSpeedMs, holdMs, preTypeDelayMs, postDeleteDelayMs, prefersReduced]);
 
   const baseClass = [
-    "relative inline-block align-baseline",
+    "inline-block whitespace-nowrap align-baseline",
     mobileBlock ? "block sm:inline" : "",
     className,
-    "whitespace-nowrap",
   ].join(" ");
 
   if (prefersReduced && reducedMotionFallback) {
-    return (
-      <span className={baseClass} style={{ minWidth: `${ch}ch` }}>
-        {reducedMotionFallback}
-      </span>
-    );
+    return <span className={baseClass}>{reducedMotionFallback}</span>;
   }
 
+  const fixed = maxW ? { width: `${maxW}px` } : undefined;
+
   return (
-    <span
-      className={baseClass}
-      style={{ minWidth: `${ch}ch` }}
-      aria-live="polite"
-      aria-atomic="true"
-    >
-      {text}
-    </span>
+    <>
+      <div
+        ref={measRef}
+        className={`${className} absolute -z-10 invisible top-0 left-0`}
+      >
+        {list.map((p, k) => (
+          <span key={k} className="inline-block whitespace-nowrap">
+            {p}
+          </span>
+        ))}
+      </div>
+      <span className={baseClass} style={fixed} aria-live="polite" aria-atomic="true">
+        {text}
+      </span>
+      <span className="sr-only">{list[0] ?? ""}</span>
+    </>
   );
 }
-

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+type Phase = "typing" | "holding" | "deleting" | "gap";
+
+type Props = {
+  phrases: string[];
+  className?: string;
+  typeSpeedMs?: number;       // per char while typing
+  deleteSpeedMs?: number;     // per char while deleting
+  holdMs?: number;            // full word on screen
+  preTypeDelayMs?: number;    // empty pause before next word begins typing
+  postDeleteDelayMs?: number; // empty pause right after clearing
+  reducedMotionFallback?: string;
+};
+
+export default function RotatingPhrase({
+  phrases,
+  className = "",
+  // >>> Readable keynote pacing <<<
+  typeSpeedMs = 240,          // ~4 chars/sec (calm)
+  deleteSpeedMs = 150,        // a touch faster than typing
+  holdMs = 3400,              // ~3.4s fully visible
+  preTypeDelayMs = 1200,      // 1.2s gap before next word starts
+  postDeleteDelayMs = 800,    // 0.8s gap after clearing
+  reducedMotionFallback = "",
+}: Props) {
+  const list = useMemo(() => phrases.filter(Boolean), [phrases]);
+
+  // StrictMode‑safe single timer
+  const t = useRef<number | null>(null);
+  const clear = () => { if (t.current) { clearTimeout(t.current); t.current = null; } };
+
+  const [text, setText] = useState("");
+  const [idx, setIdx] = useState(0);
+  const [phase, setPhase] = useState<Phase>("typing");
+
+  // lock width to the widest phrase (prevents re-centering)
+  const [maxW, setMaxW] = useState(0);
+  const measRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const measure = () => {
+      if (!measRef.current) return;
+      let w = 0;
+      for (const el of Array.from(measRef.current.children) as HTMLElement[]) w = Math.max(w, el.offsetWidth);
+      setMaxW(w);
+    };
+    // @ts-ignore
+    (document.fonts?.ready ?? Promise.resolve()).then(() => requestAnimationFrame(measure));
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [list, className]);
+
+  const prefersReduced = typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+
+  useEffect(() => {
+    if (prefersReduced) return;
+    const word = list[idx % list.length] ?? "";
+    clear();
+    const wait = (ms:number, fn:()=>void) => { t.current = window.setTimeout(fn, ms); };
+
+    if (phase === "typing") {
+      if (text.length < word.length) wait(typeSpeedMs, () => setText(word.slice(0, text.length + 1)));
+      else wait(holdMs, () => setPhase("deleting"));
+    } else if (phase === "deleting") {
+      if (text.length > 0) wait(deleteSpeedMs, () => setText(word.slice(0, text.length - 1)));
+      else wait(postDeleteDelayMs, () => setPhase("gap"));
+    } else if (phase === "gap") {
+      wait(preTypeDelayMs, () => { setIdx((i) => (i + 1) % list.length); setPhase("typing"); });
+    }
+    return clear;
+  }, [list, idx, phase, text, typeSpeedMs, deleteSpeedMs, holdMs, preTypeDelayMs, postDeleteDelayMs, prefersReduced]);
+
+  const fixed = maxW ? { width: `${maxW}px` } : undefined;
+  if (prefersReduced && reducedMotionFallback) return <span className={className}>{reducedMotionFallback}</span>;
+
+  return (
+    <>
+      {/* invisible measurement using same typography */}
+      <div ref={measRef} className={`${className} absolute -z-10 invisible top-0 left-0 whitespace-nowrap`}>
+        {list.map((p, k) => <span key={k} className="inline-block">{p}</span>)}
+      </div>
+      {/* fixed-width animated text */}
+      <span className={`inline-block whitespace-nowrap align-baseline ${className}`} style={fixed} aria-hidden="true">
+        {text}
+      </span>
+      <span className="sr-only">{list[0] ?? "governments"}</span>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add RotatingPhrase component with single timer and width locking for no layout shift
- update HeroSection to showcase slow, readable rotating phrases over hero video

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bff32a3d48331b4c722bd6f320320