### PR TITLE
Hero: rotating text wraps on mobile, inline on desktop (no layout shift)

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
+import RotatingPhrase from './RotatingPhrase';
 
 const HeroSection: React.FC = () => {
   const [isClient, setIsClient] = useState(false);
@@ -23,8 +24,18 @@ const HeroSection: React.FC = () => {
         <div className="absolute inset-0 w-full h-full bg-black" />
       )}
       <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl">
-          Pioneering <span className="text-green-500">Carbon Solutions</span>
+        <h1
+          className="text-white text-3xl md:text-5xl font-semibold tracking-tight leading-tight flex flex-wrap md:flex-nowrap items-baseline gap-x-2 text-balance"
+        >
+          <span className="opacity-90">The carbon stack for</span>
+          <span className="basis-full md:basis-auto md:ml-2">
+            <RotatingPhrase
+              phrases={["governments", "treasuries", "climate teams"]}
+              className="text-green-400"
+              reducedMotionFallback="governments"
+              responsiveWrap
+            />
+          </span>
         </h1>
         <p className="mt-6 text-white/90 text-lg md:text-xl font-medium tracking-wide">
           Technology for a sustainable future

--- a/components/RotatingPhrase.tsx
+++ b/components/RotatingPhrase.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+type Props = {
+  phrases: string[];
+  className?: string;
+  typeSpeedMs?: number;
+  deleteSpeedMs?: number;
+  holdMs?: number;
+  preTypeDelayMs?: number;
+  postDeleteDelayMs?: number;
+  reducedMotionFallback?: string;
+  responsiveWrap?: boolean; // NEW: block on mobile, inline on desktop
+};
+
+export default function RotatingPhrase({
+  phrases,
+  className = '',
+  typeSpeedMs = 110,
+  deleteSpeedMs = 70,
+  holdMs = 3200,
+  preTypeDelayMs = 1200,
+  postDeleteDelayMs = 800,
+  reducedMotionFallback = '',
+  responsiveWrap = false,
+}: Props) {
+  const list = useMemo(() => (phrases && phrases.length > 0 ? phrases : ['governments']), [phrases]);
+  const [index, setIndex] = useState(0);
+  const [text, setText] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [started, setStarted] = useState(false);
+  const [prefersReduced, setPrefersReduced] = useState(false);
+  const [w, setW] = useState<number>();
+  const measRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handle = () => setPrefersReduced(mq.matches);
+    handle();
+    mq.addEventListener('change', handle);
+    return () => mq.removeEventListener('change', handle);
+  }, []);
+
+  useEffect(() => {
+    if (measRef.current) {
+      setW(measRef.current.getBoundingClientRect().width);
+    }
+  }, [list]);
+
+  useEffect(() => {
+    if (prefersReduced) return;
+    const t = setTimeout(() => setStarted(true), preTypeDelayMs);
+    return () => clearTimeout(t);
+  }, [preTypeDelayMs, prefersReduced]);
+
+  useEffect(() => {
+    if (!started || prefersReduced) return;
+    let timeout: NodeJS.Timeout;
+    const current = list[index % list.length];
+
+    if (!isDeleting) {
+      if (text.length < current.length) {
+        timeout = setTimeout(() => setText(current.slice(0, text.length + 1)), typeSpeedMs);
+      } else {
+        timeout = setTimeout(() => setIsDeleting(true), holdMs);
+      }
+    } else {
+      if (text.length > 0) {
+        timeout = setTimeout(() => setText(current.slice(0, text.length - 1)), deleteSpeedMs);
+      } else {
+        timeout = setTimeout(() => {
+          setIsDeleting(false);
+          setIndex((i) => (i + 1) % list.length);
+        }, postDeleteDelayMs);
+      }
+    }
+
+    return () => clearTimeout(timeout);
+  }, [
+    text,
+    isDeleting,
+    started,
+    index,
+    list,
+    typeSpeedMs,
+    deleteSpeedMs,
+    holdMs,
+    postDeleteDelayMs,
+    prefersReduced,
+  ]);
+
+  const styleVar = w ? ({ ['--rotW' as any]: `${w}px` } as React.CSSProperties) : undefined;
+  if (prefersReduced && reducedMotionFallback)
+    return <span className={className}>{reducedMotionFallback}</span>;
+
+  return (
+    <>
+      <div
+        ref={measRef}
+        className={`${className} absolute -z-10 invisible top-0 left-0 whitespace-nowrap`}
+      >
+        {list.map((p, k) => (
+          <span key={k} className="inline-block">
+            {p}
+          </span>
+        ))}
+      </div>
+
+      <span
+        className={[
+          // Mobile: allow wrapping + natural width. Desktop: inline, no-wrap, fixed width.
+          responsiveWrap
+            ? 'block sm:inline-block sm:whitespace-nowrap whitespace-normal'
+            : 'inline-block whitespace-nowrap',
+          'align-baseline',
+          // Tailwind arbitrary property to apply width var only on sm+
+          'sm:[width:var(--rotW)]',
+          className,
+        ].join(' ')}
+        style={styleVar}
+        aria-hidden="true"
+      >
+        {text}
+      </span>
+
+      <span className="sr-only">{list[0] ?? 'governments'}</span>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Allow hero heading to wrap on small screens while keeping inline layout on desktop
- Add `responsiveWrap` option to `RotatingPhrase` and reserve width on desktop to prevent layout shifts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689c2f9930a88331b15c3928e57fc93a