### PR TITLE
Update hero section text and CTA

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -31,7 +31,7 @@ const HeroSection: React.FC = () => {
         </p>
         <Link
           href="/contact"
-          className="mt-10 inline-block rounded-md bg-white px-6 py-3 text-base font-semibold text-green-500 shadow-lg transition hover:bg-green-50"
+          className="mt-10 inline-block rounded-md bg-white/10 px-6 py-3 text-base font-semibold text-white backdrop-blur-sm border border-white/20 shadow-lg transition hover:bg-white/20"
         >
           Book an expert
         </Link>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -24,16 +24,16 @@ const HeroSection: React.FC = () => {
       )}
       <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
         <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl">
-          Pioneering <span className="text-green-500">Carbon Solutions</span>
+          The carbon stack for countries
         </h1>
-        <p className="mt-6 text-white/90 text-lg md:text-xl font-medium tracking-wide">
-          Technology for a sustainable future
+        <p className="mt-6 text-white text-lg md:text-xl font-medium tracking-wide">
+          We measure, we report, we verify
         </p>
         <Link
           href="/contact"
           className="mt-10 inline-block rounded-md bg-white px-6 py-3 text-base font-semibold text-green-500 shadow-lg transition hover:bg-green-50"
         >
-          Contact Us
+          Book an expert
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- revise hero heading to "The carbon stack for countries"
- make hero text fully white and update subtext to "We measure, we report, we verify"
- change CTA to "Book an expert"

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c3763d88c8331870d93a8e51994ea