### PR TITLE
Add leaderboard to projects page

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { TrophyIcon } from "@heroicons/react/24/solid";
+import { leaderboard } from "@/data/leaderboard";
+
+const medalColors = [
+  "text-yellow-500",
+  "text-gray-400",
+  "text-amber-700",
+];
+
+export default function Leaderboard() {
+  const entries = [...leaderboard].sort((a, b) => b.points - a.points);
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold tracking-tight">Leaderboard</h2>
+      <ul className="divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white">
+        {entries.map((entry, idx) => (
+          <li key={entry.name} className="flex items-center justify-between p-4">
+            <div className="flex items-center gap-3">
+              {idx < 3 ? (
+                <TrophyIcon className={`h-5 w-5 ${medalColors[idx]}`} />
+              ) : (
+                <span className="w-5 text-sm text-gray-500">{idx + 1}</span>
+              )}
+              <span className="font-medium">{entry.name}</span>
+            </div>
+            <span className="text-sm text-gray-700">{entry.points} pts</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/data/leaderboard.ts
+++ b/data/leaderboard.ts
@@ -1,0 +1,12 @@
+export interface LeaderboardEntry {
+  name: string;
+  points: number;
+}
+
+export const leaderboard: LeaderboardEntry[] = [
+  { name: "Niger State", points: 120 },
+  { name: "Kwara State", points: 95 },
+  { name: "Plateau State", points: 80 },
+  { name: "Kaduna State", points: 60 },
+  { name: "Lagos State", points: 45 },
+];

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import StateCard from "@/components/StateCard";
 import { projects } from "@/data/projects";
+import Leaderboard from "@/components/Leaderboard";
 
 export default function ProjectsPage() {
   return (
@@ -9,6 +10,8 @@ export default function ProjectsPage() {
         <h1 className="text-3xl font-semibold tracking-tight">Projects</h1>
         <p className="text-muted-foreground">Active and upcoming state engagements.</p>
       </header>
+
+      <Leaderboard />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {projects.map((p) => (


### PR DESCRIPTION
## Summary
- introduce leaderboard data and component with trophy icons
- display leaderboard on Projects page above project cards

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c66702d888331a1994dc1ba40c0e0