### PR TITLE
Leaderboard: live-only responsive UI; cards preserved with extras

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,107 +1,178 @@
-import React, { useMemo, useState } from "react";
-import { Trophy, Sparkles } from "lucide-react";
-import { computeScore } from "@/lib/score";
+import * as React from "react";
 
 type Item = {
   slug: string;
   title: string;
-  progress?: number;
-  activityScore?: number;
-  lastUpdateISO?: string;
+  los_signed?: boolean;
+  mou_signed?: boolean;
+  fera_signed?: boolean;
+  meetings_count?: number;
+  meetings_30d?: number;
+  last_update_iso?: string;
+  evidence_urls?: string; // comma-separated
 };
 
-export default function Leaderboard({ items }: { items: Item[] }) {
-  const [sortKey, setSortKey] = useState<"score"|"progress"|"activity">("score");
-  const ranked = useMemo(() => {
-    const arr = items.map(i => ({...i, score: computeScore(i)}));
-    arr.sort((a,b) => {
-      if (sortKey === "progress") return (b.progress ?? 0) - (a.progress ?? 0);
-      if (sortKey === "activity") return (b.activityScore ?? 0) - (a.activityScore ?? 0);
-      return (b.score ?? 0) - (a.score ?? 0);
-    });
-    return arr;
-  }, [items, sortKey]);
+type Props = { items: Item[]; pollMs?: number };
 
-  const topSlug = ranked[0]?.slug;
+const relTime = (iso?: string) => {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime(); if (isNaN(t)) return iso;
+  const s = Math.floor((Date.now() - t) / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60); if (m < 60) return m + "m ago";
+  const h = Math.floor(m / 60); if (h < 24) return h + "h ago";
+  const d = Math.floor(h / 24); if (d < 30) return d + "d ago";
+  const mo = Math.floor(d / 30); if (mo < 12) return mo + "mo ago";
+  return Math.floor(mo / 12) + "y ago";
+};
+
+const phase = (x: Item) => x.fera_signed ? {t:"FERA", c:"bg-emerald-600"} :
+                              x.mou_signed  ? {t:"MOU",  c:"bg-blue-600"} :
+                              x.los_signed  ? {t:"LOS",  c:"bg-amber-600"} :
+                                              {t:"Prospect", c:"bg-zinc-500"};
+
+const firstUrl = (s?: string) => s?.split(",").map(x=>x.trim()).filter(Boolean)[0];
+
+const sortKey = (x: Item) => {
+  const rank = x.fera_signed ? 3 : x.mou_signed ? 2 : x.los_signed ? 1 : 0;
+  return -(rank * 1_000_000 + (x.meetings_30d || 0) * 1_000 + (x.meetings_count || 0));
+};
+
+export default function Leaderboard({ items, pollMs = 45000 }: Props) {
+  const [live, setLive] = React.useState<Item[]>(() => {
+    const dedup = new Map(items.map(i => [i.slug, i]));
+    return Array.from(dedup.values());
+  });
+  const [syncAt, setSyncAt] = React.useState<Date | null>(null);
+
+  React.useEffect(() => {
+    const id = setInterval(async () => {
+      try {
+        const r = await fetch("/api/leaderboard");
+        const j = await r.json();
+        const arr: Item[] = Array.isArray(j.items) ? j.items : [];
+        const dedup = new Map(arr.map(i => [i.slug, i]));    // live-only; no merge with static
+        setLive(Array.from(dedup.values()));
+        setSyncAt(new Date());
+      } catch { /* ignore */ }
+    }, pollMs);
+    return () => clearInterval(id);
+  }, [pollMs]);
+
+  const data = React.useMemo(() => [...live].sort((a,b)=>sortKey(a)-sortKey(b)), [live]);
+  const feed = React.useMemo(() => {
+    return [...live]
+      .filter(i => i.last_update_iso)
+      .sort((a,b)=>new Date(b.last_update_iso||0).getTime()-new Date(a.last_update_iso||0).getTime())
+      .slice(0,6);
+  }, [live]);
 
   return (
-    <section className="rounded-xl border bg-white/70 backdrop-blur-sm shadow-sm p-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+    <section className="rounded-2xl border bg-white/60 backdrop-blur p-4 md:p-6 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <Trophy className="w-5 h-5 text-yellow-500" aria-hidden />
-          <h2 className="text-lg font-semibold tracking-tight">Leaderboard</h2>
-          {topSlug ? <span className="ml-2 inline-flex items-center text-xs text-green-700 bg-green-100 rounded px-2 py-0.5">
-            <Sparkles className="w-3 h-3 mr-1" /> {ranked[0].title}
-          </span> : null}
+          <h2 className="text-xl font-semibold tracking-tight">Leaderboard</h2>
+          <span className="relative inline-flex items-center">
+            <span className="animate-ping absolute inline-flex h-2 w-2 rounded-full bg-emerald-500 opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-600"></span>
+          </span>
+          <span className="text-xs text-emerald-600 font-medium">live</span>
         </div>
-        <div className="flex items-center gap-2 text-sm">
-          <button onClick={() => setSortKey("score")}
-            className={`px-2 py-1 rounded border ${sortKey==="score"?"bg-black text-white":"bg-white hover:bg-gray-50"}`}>
-            Overall
-          </button>
-          <button onClick={() => setSortKey("progress")}
-            className={`px-2 py-1 rounded border ${sortKey==="progress"?"bg-black text-white":"bg-white hover:bg-gray-50"}`}>
-            Progress
-          </button>
-          <button onClick={() => setSortKey("activity")}
-            className={`px-2 py-1 rounded border ${sortKey==="activity"?"bg-black text-white":"bg-white hover:bg-gray-50"}`}>
-            Activity
-          </button>
-        </div>
+        <span className="text-xs text-zinc-500">
+          {syncAt ? `Updated ${relTime(syncAt.toISOString())}` : `Auto-refresh ~${Math.round(pollMs/1000)}s`}
+        </span>
       </div>
 
-      <ol className="space-y-2 max-h-[420px] overflow-auto pr-1">
-        {ranked.map((p, idx) => {
-          const borderColor =
-            idx === 0 ? "border-yellow-200" :
-            idx === 1 ? "border-gray-200" :
-            idx === 2 ? "border-amber-200" :
-            "border-gray-200";
+      {/* Mobile-first compact list */}
+      <ul className="md:hidden space-y-2">
+        {data.map(x => {
+          const ph = phase(x);
+          const url = firstUrl(x.evidence_urls);
           return (
-            <li key={p.slug}
-                data-slug={p.slug}
-                className={`group flex items-center gap-3 rounded-lg border ${borderColor} bg-white/80 hover:bg-white hover:-translate-y-0.5 transition p-3`}
-                onMouseEnter={() => highlightCard(p.slug, true)}
-                onMouseLeave={() => highlightCard(p.slug, false)}
-            >
-              <span className="w-6 text-sm font-bold text-gray-500">{idx+1}</span>
-              <span className="flex-1 font-medium truncate">{p.title}</span>
-
-              {/* Progress bar */}
-              <div className="hidden sm:flex flex-1 items-center gap-2">
-                <div className="h-2 w-full bg-gray-200 rounded-full overflow-hidden">
-                  <div className="h-full bg-green-500 transition-all duration-700 ease-out"
-                       style={{ width: `${Math.max(0, Math.min(100, p.progress ?? 0))}%` }} />
-                </div>
-                <span className="w-12 text-right text-xs tabular-nums text-gray-500">{Math.round(p.progress ?? 0)}%</span>
+            <li key={x.slug} className="rounded-xl border p-3 flex items-center justify-between">
+              <div>
+                <div className="font-medium">{x.title || x.slug}</div>
+                <div className="text-xs text-zinc-500">{relTime(x.last_update_iso)}</div>
               </div>
-
-              {/* Scores */}
-              <div className="w-24 text-right">
-                <span className="inline-flex items-center justify-end text-sm font-semibold tabular-nums">
-                  {sortKey==="progress" ? Math.round(p.progress ?? 0)
-                   : sortKey==="activity" ? Math.round(p.activityScore ?? 0)
-                   : Math.round(p.score ?? 0)}
-                </span>
+              <div className="flex items-center gap-2">
+                <span className={`px-2 py-0.5 rounded-full text-[10px] font-medium text-white ${ph.c}`}>{ph.t}</span>
+                {typeof x.meetings_30d === "number" && (
+                  <span className="px-2 py-0.5 rounded-full text-[10px] bg-zinc-100 text-zinc-700">{x.meetings_30d} in 30d</span>
+                )}
+                {url ? (
+                  <a href={url} target="_blank" rel="noreferrer" className="text-xs font-medium text-emerald-700 hover:underline">View</a>
+                ) : null}
               </div>
             </li>
           );
         })}
-      </ol>
+        {data.length === 0 && <li className="text-sm text-zinc-500 text-center py-6">No live data yet</li>}
+      </ul>
 
-      <p className="mt-2 text-xs text-gray-500">
-        Overall score weights progress (60%), activity (30%), and recency (10%).
-      </p>
+      {/* Desktop table */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="text-left text-zinc-500 border-b">
+            <tr>
+              <th className="py-2 pr-4">State</th>
+              <th className="py-2 pr-4">Status</th>
+              <th className="py-2 pr-4">Meetings</th>
+              <th className="py-2 pr-4">Last update</th>
+              <th className="py-2 pr-0">Evidence</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map(x => {
+              const ph = phase(x);
+              const url = firstUrl(x.evidence_urls);
+              return (
+                <tr key={x.slug} className="border-b last:border-0">
+                  <td className="py-3 pr-4 font-medium">{x.title || x.slug}</td>
+                  <td className="py-3 pr-4">
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium text-white ${ph.c}`}>{ph.t}</span>
+                  </td>
+                  <td className="py-3 pr-4">
+                    <div className="font-medium">{x.meetings_count ?? 0}</div>
+                    <div className="text-xs text-zinc-500">{x.meetings_30d ?? 0} in 30d</div>
+                  </td>
+                  <td className="py-3 pr-4">
+                    <div className="font-medium">{relTime(x.last_update_iso)}</div>
+                    <div className="text-xs text-zinc-500">{(x.last_update_iso || "—").slice(0,10)}</div>
+                  </td>
+                  <td className="py-3 pr-0">
+                    {url ? <a href={url} target="_blank" rel="noreferrer" className="text-xs font-medium text-emerald-700 hover:underline">View</a> : <span className="text-xs text-zinc-400">—</span>}
+                  </td>
+                </tr>
+              );
+            })}
+            {data.length === 0 && (
+              <tr><td colSpan={5} className="py-8 text-center text-zinc-500">No live data yet</td></tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mini feed */}
+      <div className="mt-6">
+        <h3 className="text-sm font-medium text-zinc-600 mb-2">Live feed</h3>
+        <div className="grid sm:grid-cols-2 gap-3">
+          {feed.map(x => (
+            <div key={x.slug} className="rounded-xl border p-3">
+              <div className="flex items-center justify-between">
+                <div className="font-medium">{x.title || x.slug}</div>
+                <span className="text-xs text-zinc-500">{relTime(x.last_update_iso)}</span>
+              </div>
+              <div className="text-xs text-zinc-600 mt-1">
+                {(x.fera_signed && "Framework Agreement activity") ||
+                 (x.mou_signed && "MOU activity") ||
+                 (x.los_signed && "LOS activity") || "Engagement updates"}
+              </div>
+            </div>
+          ))}
+          {feed.length === 0 && <div className="text-sm text-zinc-500">Updates will appear here.</div>}
+        </div>
+      </div>
     </section>
   );
 }
 
-// Simple highlight hook-up: add ring to matching StateCard in the grid
-function highlightCard(slug: string, on: boolean) {
-  const el = document.querySelector(`[data-state-slug="${slug}"]`);
-  if (!el) return;
-  el.classList.toggle("ring-2", on);
-  el.classList.toggle("ring-green-500", on);
-  el.classList.toggle("ring-offset-2", on);
-  el.classList.toggle("ring-offset-white", on);
-}

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -1,9 +1,76 @@
 import React from "react";
+import type { GetServerSideProps } from "next";
 import StateCard from "@/components/StateCard";
 import Leaderboard from "@/components/Leaderboard";
-import { projects } from "@/data/projects";
+import { projects as localProjects } from "@/data/projects";
 
-export default function ProjectsPage() {
+type ApiItem = {
+  slug: string;
+  title: string;
+  los_signed?: boolean;
+  mou_signed?: boolean;
+  fera_signed?: boolean;
+  meetings_count?: number;
+  meetings_30d?: number;
+  last_update_iso?: string;
+  evidence_urls?: string;
+};
+
+type CardItem = ApiItem & {
+  epithet?: string;
+  summary?: string;
+  status?: string;
+  tags?: string[];
+  updatedAt?: string;
+  ctaLabel?: string;
+  progress?: number;
+  activityScore?: number;
+  lastUpdateISO?: string;
+};
+
+type Props = { live: ApiItem[]; cards: CardItem[] };
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ req }) => {
+  const proto = (req.headers["x-forwarded-proto"] as string) || "http";
+  const host  = req.headers.host;
+  const base  = `${proto}://${host}`;
+
+  try {
+    const r = await fetch(`${base}/api/leaderboard`, { headers: { "x-internal": "1" } });
+    const j = await r.json();
+    const apiItems: ApiItem[] = Array.isArray(j.items) ? j.items : [];
+
+    // Cards: merge live onto static extras (keep your rich content)
+    const extrasMap = Object.fromEntries(localProjects.map(p => [p.slug, p]));
+    const merged = apiItems.map(api => ({
+      ...(extrasMap[api.slug] || {}),
+      ...api,
+      lastUpdateISO: api.last_update_iso || (extrasMap[api.slug]?.lastUpdateISO),
+    }));
+    // Include any static-only entries not yet in the sheet (so the 3 cards still show)
+    const missing = localProjects
+      .filter(p => !apiItems.some(a => a.slug === p.slug))
+      .map(p => ({
+        ...p,
+        los_signed: false, mou_signed: false, fera_signed: false,
+        meetings_count: 0, meetings_30d: 0,
+        last_update_iso: p.lastUpdateISO,
+      }));
+
+    return { props: { live: apiItems, cards: [...merged, ...missing] } };
+  } catch {
+    // If API fails, show cards only (static)
+    const fallback = localProjects.map(p => ({
+      ...p,
+      los_signed: false, mou_signed: false, fera_signed: false,
+      meetings_count: 0, meetings_30d: 0,
+      last_update_iso: p.lastUpdateISO,
+    }));
+    return { props: { live: [], cards: fallback } };
+  }
+};
+
+export default function ProjectsPage({ live, cards }: Props) {
   return (
     <main className="max-w-6xl mx-auto p-6 space-y-6">
       <header className="space-y-2">
@@ -11,13 +78,16 @@ export default function ProjectsPage() {
         <p className="text-muted-foreground">Active and upcoming state engagements.</p>
       </header>
 
-      <Leaderboard items={projects as any} />
+      {/* Live-only leaderboard */}
+      <Leaderboard items={live} pollMs={45000} />
 
+      {/* Preserved rich project cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {projects.map((p) => (
+        {cards.map((p) => (
           <StateCard key={p.slug} {...p} />
         ))}
       </div>
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- fetch leaderboard on Projects page and merge live data with static project extras
- redesign Leaderboard component to show live-only items with responsive list and table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d886dc1a483318049fa5dd660e6b9