### PR TITLE
Leaderboard: meaningful live metrics (Stage, Momentum, Touchpoints, Recency, Evidence)

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,107 +1,156 @@
-import React, { useMemo, useState } from "react";
-import { Trophy, Sparkles } from "lucide-react";
-import { computeScore } from "@/lib/score";
+import * as React from "react";
 
 type Item = {
   slug: string;
   title: string;
-  progress?: number;
-  activityScore?: number;
-  lastUpdateISO?: string;
+  los_signed?: boolean;
+  mou_signed?: boolean;
+  fera_signed?: boolean;
+  meetings_count?: number;
+  meetings_30d?: number;
+  last_update_iso?: string;
+  evidence_urls?: string; // comma-separated
 };
 
-export default function Leaderboard({ items }: { items: Item[] }) {
-  const [sortKey, setSortKey] = useState<"score"|"progress"|"activity">("score");
-  const ranked = useMemo(() => {
-    const arr = items.map(i => ({...i, score: computeScore(i)}));
-    arr.sort((a,b) => {
-      if (sortKey === "progress") return (b.progress ?? 0) - (a.progress ?? 0);
-      if (sortKey === "activity") return (b.activityScore ?? 0) - (a.activityScore ?? 0);
-      return (b.score ?? 0) - (a.score ?? 0);
-    });
-    return arr;
-  }, [items, sortKey]);
+type Props = { items: Item[]; pollMs?: number };
 
-  const topSlug = ranked[0]?.slug;
+function stageInfo(x: Item) {
+  if (x.fera_signed) return { label: "FERA", weight: 3, cls: "bg-emerald-600" };
+  if (x.mou_signed)  return { label: "MOU",  weight: 2, cls: "bg-blue-600" };
+  if (x.los_signed)  return { label: "LOS",  weight: 1, cls: "bg-amber-600" };
+  return { label: "Prospect", weight: 0, cls: "bg-zinc-500" };
+}
+
+function relTime(iso?: string) {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return iso;
+  const s = Math.floor((Date.now() - t) / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60); if (m < 60) return m + "m ago";
+  const h = Math.floor(m / 60); if (h < 24) return h + "h ago";
+  const d = Math.floor(h / 24); if (d < 30) return d + "d ago";
+  const mo = Math.floor(d / 30); if (mo < 12) return mo + "mo ago";
+  return Math.floor(mo / 12) + "y ago";
+}
+
+function firstUrl(s?: string) {
+  if (!s) return undefined;
+  const parts = s.split(",").map(v => v.trim()).filter(Boolean);
+  return parts[0];
+}
+
+function sortKey(x: Item) {
+  const st = stageInfo(x).weight;
+  const m30 = x.meetings_30d || 0;
+  const total = x.meetings_count || 0;
+  const recency = x.last_update_iso ? (1e6 - new Date(x.last_update_iso).getTime()) : 0; // newer first
+  return -(st * 1_000_000_000 + m30 * 1_000_000 + total * 1_000 + recency);
+}
+
+export default function Leaderboard({ items, pollMs = 45000 }: Props) {
+  const [live, setLive] = React.useState<Item[]>(() => Array.from(new Map(items.map(i => [i.slug, i])).values()));
+  const [syncedAt, setSyncedAt] = React.useState<string | null>(null);
+
+  // Client polling (keeps SSR fast; UI updates live)
+  React.useEffect(() => {
+    const id = setInterval(async () => {
+      try {
+        const r = await fetch("/api/leaderboard", { cache: "no-store" });
+        const j = await r.json();
+        const arr: Item[] = Array.isArray(j.items) ? j.items : [];
+        const dedup = new Map(arr.map(i => [i.slug, i]));
+        setLive(Array.from(dedup.values()));
+        setSyncedAt(new Date().toISOString());
+      } catch {}
+    }, pollMs);
+    return () => clearInterval(id);
+  }, [pollMs]);
+
+  const data = React.useMemo(() => [...live].sort((a,b)=>sortKey(a)-sortKey(b)), [live]);
 
   return (
-    <section className="rounded-xl border bg-white/70 backdrop-blur-sm shadow-sm p-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+    <section className="rounded-2xl border bg-white/60 backdrop-blur p-4 md:p-6 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <Trophy className="w-5 h-5 text-yellow-500" aria-hidden />
-          <h2 className="text-lg font-semibold tracking-tight">Leaderboard</h2>
-          {topSlug ? <span className="ml-2 inline-flex items-center text-xs text-green-700 bg-green-100 rounded px-2 py-0.5">
-            <Sparkles className="w-3 h-3 mr-1" /> {ranked[0].title}
-          </span> : null}
+          <h2 className="text-xl font-semibold tracking-tight">Leaderboard</h2>
+          <span className="relative inline-flex items-center">
+            <span className="animate-ping absolute inline-flex h-2 w-2 rounded-full bg-emerald-500 opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-600"></span>
+          </span>
+          <span className="text-xs text-emerald-700 font-medium">live</span>
         </div>
-        <div className="flex items-center gap-2 text-sm">
-          <button onClick={() => setSortKey("score")}
-            className={`px-2 py-1 rounded border ${sortKey==="score"?"bg-black text-white":"bg-white hover:bg-gray-50"}`}>
-            Overall
-          </button>
-          <button onClick={() => setSortKey("progress")}
-            className={`px-2 py-1 rounded border ${sortKey==="progress"?"bg-black text-white":"bg-white hover:bg-gray-50"}`}>
-            Progress
-          </button>
-          <button onClick={() => setSortKey("activity")}
-            className={`px-2 py-1 rounded border ${sortKey==="activity"?"bg-black text-white":"bg-white hover:bg-gray-50"}`}>
-            Activity
-          </button>
-        </div>
+        <span className="text-xs text-zinc-500">
+          {syncedAt ? "Updated " + relTime(syncedAt) : "Auto-refresh ~" + Math.round(pollMs/1000) + "s"}
+        </span>
       </div>
 
-      <ol className="space-y-2 max-h-[420px] overflow-auto pr-1">
-        {ranked.map((p, idx) => {
-          const borderColor =
-            idx === 0 ? "border-yellow-200" :
-            idx === 1 ? "border-gray-200" :
-            idx === 2 ? "border-amber-200" :
-            "border-gray-200";
+      {/* Mobile: compact cards */}
+      <ul className="md:hidden space-y-2">
+        {data.map((x) => {
+          const st = stageInfo(x);
+          const url = firstUrl(x.evidence_urls);
           return (
-            <li key={p.slug}
-                data-slug={p.slug}
-                className={`group flex items-center gap-3 rounded-lg border ${borderColor} bg-white/80 hover:bg-white hover:-translate-y-0.5 transition p-3`}
-                onMouseEnter={() => highlightCard(p.slug, true)}
-                onMouseLeave={() => highlightCard(p.slug, false)}
-            >
-              <span className="w-6 text-sm font-bold text-gray-500">{idx+1}</span>
-              <span className="flex-1 font-medium truncate">{p.title}</span>
-
-              {/* Progress bar */}
-              <div className="hidden sm:flex flex-1 items-center gap-2">
-                <div className="h-2 w-full bg-gray-200 rounded-full overflow-hidden">
-                  <div className="h-full bg-green-500 transition-all duration-700 ease-out"
-                       style={{ width: `${Math.max(0, Math.min(100, p.progress ?? 0))}%` }} />
-                </div>
-                <span className="w-12 text-right text-xs tabular-nums text-gray-500">{Math.round(p.progress ?? 0)}%</span>
+            <li key={x.slug} className="rounded-xl border p-3">
+              <div className="flex items-center justify-between">
+                <div className="font-medium">{x.title || x.slug}</div>
+                <span className={`px-2 py-0.5 rounded-full text-[10px] text-white ${st.cls}`}>{st.label}</span>
               </div>
-
-              {/* Scores */}
-              <div className="w-24 text-right">
-                <span className="inline-flex items-center justify-end text-sm font-semibold tabular-nums">
-                  {sortKey==="progress" ? Math.round(p.progress ?? 0)
-                   : sortKey==="activity" ? Math.round(p.activityScore ?? 0)
-                   : Math.round(p.score ?? 0)}
-                </span>
+              <div className="mt-1 text-xs text-zinc-600 flex items-center gap-2">
+                <span>{x.meetings_30d ?? 0} in 30d</span>
+                <span>•</span>
+                <span>{x.meetings_count ?? 0} total</span>
+                <span>•</span>
+                <span>{relTime(x.last_update_iso)}</span>
+                {url ? (<><span>•</span><a className="font-medium text-emerald-700 hover:underline" href={url} target="_blank" rel="noreferrer">Evidence</a></>) : null}
               </div>
             </li>
           );
         })}
-      </ol>
+        {data.length === 0 && <li className="text-sm text-zinc-500 text-center py-6">No live data yet</li>}
+      </ul>
 
-      <p className="mt-2 text-xs text-gray-500">
-        Overall score weights progress (60%), activity (30%), and recency (10%).
-      </p>
+      {/* Desktop: clear table of essentials */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="text-left text-zinc-500 border-b">
+            <tr>
+              <th className="py-2 pr-4">State</th>
+              <th className="py-2 pr-4">Stage</th>
+              <th className="py-2 pr-4">Momentum (30d)</th>
+              <th className="py-2 pr-4">Touchpoints</th>
+              <th className="py-2 pr-4">Last update</th>
+              <th className="py-2 pr-0">Evidence</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((x) => {
+              const st = stageInfo(x);
+              const url = firstUrl(x.evidence_urls);
+              return (
+                <tr key={x.slug} className="border-b last:border-0">
+                  <td className="py-3 pr-4 font-medium">{x.title || x.slug}</td>
+                  <td className="py-3 pr-4">
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium text-white ${st.cls}`}>{st.label}</span>
+                  </td>
+                  <td className="py-3 pr-4">{x.meetings_30d ?? 0}</td>
+                  <td className="py-3 pr-4">{x.meetings_count ?? 0}</td>
+                  <td className="py-3 pr-4">
+                    <div className="font-medium">{relTime(x.last_update_iso)}</div>
+                    <div className="text-xs text-zinc-500">{(x.last_update_iso || "—").slice(0,10)}</div>
+                  </td>
+                  <td className="py-3 pr-0">
+                    {url ? <a href={url} target="_blank" rel="noreferrer" className="text-xs font-medium text-emerald-700 hover:underline">View</a> : <span className="text-xs text-zinc-400">—</span>}
+                  </td>
+                </tr>
+              );
+            })}
+            {data.length === 0 && (
+              <tr><td colSpan={6} className="py-8 text-center text-zinc-500">No live data yet</td></tr>
+            )}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
-}
-
-// Simple highlight hook-up: add ring to matching StateCard in the grid
-function highlightCard(slug: string, on: boolean) {
-  const el = document.querySelector(`[data-state-slug="${slug}"]`);
-  if (!el) return;
-  el.classList.toggle("ring-2", on);
-  el.classList.toggle("ring-green-500", on);
-  el.classList.toggle("ring-offset-2", on);
-  el.classList.toggle("ring-offset-white", on);
 }

--- a/lib/leaderboard.ts
+++ b/lib/leaderboard.ts
@@ -1,0 +1,59 @@
+export type LiveItem = {
+  slug: string;
+  title: string;
+  los_signed?: boolean;
+  mou_signed?: boolean;
+  fera_signed?: boolean;
+  meetings_count?: number;
+  meetings_30d?: number;
+  last_update_iso?: string;
+  evidence_urls?: string;
+};
+
+function parseBool(v: any): boolean | undefined {
+  if (v === undefined || v === null || v === "") return undefined;
+  if (typeof v === "boolean") return v;
+  const s = String(v).toLowerCase();
+  if (s === "true" || s === "1" || s === "yes") return true;
+  if (s === "false" || s === "0" || s === "no") return false;
+  return undefined;
+}
+
+function parseNum(v: any): number | undefined {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export async function getLeaderboard(): Promise<LiveItem[]> {
+  const sheetId = process.env.LEADERBOARD_SHEET_ID;
+  const gid = process.env.LEADERBOARD_GID || "0";
+  if (!sheetId) return [];
+  try {
+    const url = `https://docs.google.com/spreadsheets/d/${sheetId}/gviz/tq?tqx=out:csv&gid=${gid}`;
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const text = await res.text();
+    const rows = text.trim().split(/\r?\n/).map((l) => l.split(","));
+    const header = rows.shift() || [];
+    const items: LiveItem[] = [];
+    for (const row of rows) {
+      const obj: any = {};
+      header.forEach((h, i) => (obj[h] = row[i]));
+      if (!obj.slug) continue;
+      items.push({
+        slug: obj.slug,
+        title: obj.title,
+        los_signed: parseBool(obj.los_signed),
+        mou_signed: parseBool(obj.mou_signed),
+        fera_signed: parseBool(obj.fera_signed),
+        meetings_count: parseNum(obj.meetings_count),
+        meetings_30d: parseNum(obj.meetings_30d),
+        last_update_iso: obj.last_update_iso,
+        evidence_urls: obj.evidence_urls,
+      });
+    }
+    return items;
+  } catch {
+    return [];
+  }
+}

--- a/pages/api/leaderboard.ts
+++ b/pages/api/leaderboard.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getLeaderboard } from "@/lib/leaderboard";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const items = await getLeaderboard();
+    res.status(200).json({ ok: true, items });
+  } catch (err: any) {
+    res.status(500).json({ ok: false, items: [], error: err?.message || "failed" });
+  }
+}

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import StateCard from "@/components/StateCard";
 import Leaderboard from "@/components/Leaderboard";
 import { projects } from "@/data/projects";
+import { getLeaderboard, LiveItem } from "@/lib/leaderboard";
 
-export default function ProjectsPage() {
+export default function ProjectsPage({ live }: { live: LiveItem[] }) {
   return (
     <main className="max-w-6xl mx-auto p-6 space-y-6">
       <header className="space-y-2">
@@ -11,7 +12,7 @@ export default function ProjectsPage() {
         <p className="text-muted-foreground">Active and upcoming state engagements.</p>
       </header>
 
-      <Leaderboard items={projects as any} />
+      <Leaderboard items={live} pollMs={45000} />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {projects.map((p) => (
@@ -20,4 +21,9 @@ export default function ProjectsPage() {
       </div>
     </main>
   );
+}
+
+export async function getServerSideProps() {
+  const live = await getLeaderboard();
+  return { props: { live } };
 }


### PR DESCRIPTION
## Summary
- introduce live leaderboard fetch helper to parse Google Sheet rows into typed items
- serve leaderboard data via new API route and consume on projects page
- redesign Leaderboard component with responsive layout displaying stage, momentum, touchpoints, recency, and evidence

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d9e0d525c8331a619cbe9d9fafd85