### PR TITLE
Fix API shape to be strictly live + 3-metric UI (no static merge)

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,107 +1,122 @@
-import React, { useMemo, useState } from "react";
-import { Trophy, Sparkles } from "lucide-react";
-import { computeScore } from "@/lib/score";
+import * as React from "react";
 
 type Item = {
   slug: string;
   title: string;
-  progress?: number;
-  activityScore?: number;
-  lastUpdateISO?: string;
+  los_signed: boolean;
+  mou_signed: boolean;
+  fera_signed: boolean;
+  meetings_30d: number;
+  last_update_iso: string;
 };
 
-export default function Leaderboard({ items }: { items: Item[] }) {
-  const [sortKey, setSortKey] = useState<"score"|"progress"|"activity">("score");
-  const ranked = useMemo(() => {
-    const arr = items.map(i => ({...i, score: computeScore(i)}));
-    arr.sort((a,b) => {
-      if (sortKey === "progress") return (b.progress ?? 0) - (a.progress ?? 0);
-      if (sortKey === "activity") return (b.activityScore ?? 0) - (a.activityScore ?? 0);
-      return (b.score ?? 0) - (a.score ?? 0);
-    });
-    return arr;
-  }, [items, sortKey]);
+type Props = { items: Item[]; pollMs?: number };
 
-  const topSlug = ranked[0]?.slug;
+const stage = (x: Item) =>
+  x.fera_signed ? { t: "FERA", c: "bg-emerald-600" } :
+  x.mou_signed  ? { t: "MOU",  c: "bg-blue-600" } :
+  x.los_signed  ? { t: "LOS",  c: "bg-amber-600" } :
+                  { t: "Prospect", c: "bg-zinc-500" };
+
+const rel = (iso?: string) => {
+  if (!iso) return "—";
+  const ts = new Date(iso).getTime(); if (isNaN(ts)) return iso;
+  const s = Math.floor((Date.now() - ts)/1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s/60); if (m < 60) return m+"m ago";
+  const h = Math.floor(m/60); if (h < 24) return h+"h ago";
+  const d = Math.floor(h/24); if (d < 30) return d+"d ago";
+  const mo = Math.floor(d/30); if (mo < 12) return mo+"mo ago";
+  return Math.floor(mo/12)+"y ago";
+};
+
+const sortKey = (x: Item) => {
+  const rank = x.fera_signed ? 3 : x.mou_signed ? 2 : x.los_signed ? 1 : 0;
+  return -(rank*1_000_000 + (x.meetings_30d||0)*1_000 + (x.last_update_iso ? new Date(x.last_update_iso).getTime() : 0));
+};
+
+export default function Leaderboard({ items, pollMs = 45000 }: Props) {
+  const [live, setLive] = React.useState<Item[]>(() => Array.from(new Map(items.map(i=>[i.slug,i])).values()));
+
+  React.useEffect(() => {
+    const id = setInterval(async () => {
+      try {
+        const r = await fetch("/api/leaderboard", { cache: "no-store" });
+        const j = await r.json();
+        const arr: Item[] = Array.isArray(j.items) ? j.items : [];
+        setLive(Array.from(new Map(arr.map(i=>[i.slug,i])).values()));
+      } catch {}
+    }, pollMs);
+    return () => clearInterval(id);
+  }, [pollMs]);
+
+  const data = React.useMemo(() => [...live].sort((a,b)=>sortKey(a)-sortKey(b)), [live]);
 
   return (
-    <section className="rounded-xl border bg-white/70 backdrop-blur-sm shadow-sm p-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
-        <div className="flex items-center gap-2">
-          <Trophy className="w-5 h-5 text-yellow-500" aria-hidden />
-          <h2 className="text-lg font-semibold tracking-tight">Leaderboard</h2>
-          {topSlug ? <span className="ml-2 inline-flex items-center text-xs text-green-700 bg-green-100 rounded px-2 py-0.5">
-            <Sparkles className="w-3 h-3 mr-1" /> {ranked[0].title}
-          </span> : null}
-        </div>
-        <div className="flex items-center gap-2 text-sm">
-          <button onClick={() => setSortKey("score")}
-            className={`px-2 py-1 rounded border ${sortKey==="score"?"bg-black text-white":"bg-white hover:bg-gray-50"}`}>
-            Overall
-          </button>
-          <button onClick={() => setSortKey("progress")}
-            className={`px-2 py-1 rounded border ${sortKey==="progress"?"bg-black text-white":"bg-white hover:bg-gray-50"}`}>
-            Progress
-          </button>
-          <button onClick={() => setSortKey("activity")}
-            className={`px-2 py-1 rounded border ${sortKey==="activity"?"bg-black text-white":"bg-white hover:bg-gray-50"}`}>
-            Activity
-          </button>
-        </div>
+    <section className="rounded-2xl border bg-white/60 backdrop-blur p-4 md:p-6 shadow-sm">
+      <div className="flex items-center gap-2 mb-4">
+        <h2 className="text-xl font-semibold tracking-tight">Leaderboard</h2>
+        <span className="relative inline-flex items-center">
+          <span className="animate-ping absolute inline-flex h-2 w-2 rounded-full bg-emerald-500 opacity-75"></span>
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-600"></span>
+        </span>
+        <span className="text-xs text-emerald-700 font-medium">live</span>
       </div>
 
-      <ol className="space-y-2 max-h-[420px] overflow-auto pr-1">
-        {ranked.map((p, idx) => {
-          const borderColor =
-            idx === 0 ? "border-yellow-200" :
-            idx === 1 ? "border-gray-200" :
-            idx === 2 ? "border-amber-200" :
-            "border-gray-200";
+      {/* Mobile: 3 metrics compact */}
+      <ul className="md:hidden space-y-2">
+        {data.map((x) => {
+          const st = stage(x);
           return (
-            <li key={p.slug}
-                data-slug={p.slug}
-                className={`group flex items-center gap-3 rounded-lg border ${borderColor} bg-white/80 hover:bg-white hover:-translate-y-0.5 transition p-3`}
-                onMouseEnter={() => highlightCard(p.slug, true)}
-                onMouseLeave={() => highlightCard(p.slug, false)}
-            >
-              <span className="w-6 text-sm font-bold text-gray-500">{idx+1}</span>
-              <span className="flex-1 font-medium truncate">{p.title}</span>
-
-              {/* Progress bar */}
-              <div className="hidden sm:flex flex-1 items-center gap-2">
-                <div className="h-2 w-full bg-gray-200 rounded-full overflow-hidden">
-                  <div className="h-full bg-green-500 transition-all duration-700 ease-out"
-                       style={{ width: `${Math.max(0, Math.min(100, p.progress ?? 0))}%` }} />
-                </div>
-                <span className="w-12 text-right text-xs tabular-nums text-gray-500">{Math.round(p.progress ?? 0)}%</span>
+            <li key={x.slug} className="rounded-xl border p-3">
+              <div className="flex items-center justify-between">
+                <div className="font-medium">{x.title || x.slug}</div>
+                <span className={`px-2 py-0.5 rounded-full text-[10px] text-white ${st.c}`}>{st.t}</span>
               </div>
-
-              {/* Scores */}
-              <div className="w-24 text-right">
-                <span className="inline-flex items-center justify-end text-sm font-semibold tabular-nums">
-                  {sortKey==="progress" ? Math.round(p.progress ?? 0)
-                   : sortKey==="activity" ? Math.round(p.activityScore ?? 0)
-                   : Math.round(p.score ?? 0)}
-                </span>
+              <div className="mt-1 text-xs text-zinc-600 flex items-center gap-2">
+                <span>{x.meetings_30d ?? 0} in 30d</span>
+                <span>•</span>
+                <span>{rel(x.last_update_iso)}</span>
               </div>
             </li>
           );
         })}
-      </ol>
+        {data.length === 0 && <li className="text-sm text-zinc-500 text-center py-6">No live data yet</li>}
+      </ul>
 
-      <p className="mt-2 text-xs text-gray-500">
-        Overall score weights progress (60%), activity (30%), and recency (10%).
-      </p>
+      {/* Desktop: 3 columns only */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="text-left text-zinc-500 border-b">
+            <tr>
+              <th className="py-2 pr-4">State</th>
+              <th className="py-2 pr-4">Stage</th>
+              <th className="py-2 pr-4">Momentum (30d)</th>
+              <th className="py-2 pr-0">Last update</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((x) => {
+              const st = stage(x);
+              return (
+                <tr key={x.slug} className="border-b last:border-0">
+                  <td className="py-3 pr-4 font-medium">{x.title || x.slug}</td>
+                  <td className="py-3 pr-4">
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium text-white ${st.c}`}>{st.t}</span>
+                  </td>
+                  <td className="py-3 pr-4">{x.meetings_30d ?? 0}</td>
+                  <td className="py-3 pr-0">
+                    <div className="font-medium">{rel(x.last_update_iso)}</div>
+                    <div className="text-xs text-zinc-500">{(x.last_update_iso || "—").slice(0,10)}</div>
+                  </td>
+                </tr>
+              );
+            })}
+            {data.length === 0 && <tr><td colSpan={4} className="py-8 text-center text-zinc-500">No live data yet</td></tr>}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
 }
 
-// Simple highlight hook-up: add ring to matching StateCard in the grid
-function highlightCard(slug: string, on: boolean) {
-  const el = document.querySelector(`[data-state-slug="${slug}"]`);
-  if (!el) return;
-  el.classList.toggle("ring-2", on);
-  el.classList.toggle("ring-green-500", on);
-  el.classList.toggle("ring-offset-2", on);
-  el.classList.toggle("ring-offset-white", on);
-}

--- a/lib/leaderboard.ts
+++ b/lib/leaderboard.ts
@@ -1,0 +1,65 @@
+import { google } from "googleapis";
+
+export type LiveItem = {
+  slug: string;
+  title: string;
+  los_signed: boolean;
+  mou_signed: boolean;
+  fera_signed: boolean;
+  meetings_count: number;
+  meetings_30d: number;
+  last_update_iso: string;   // YYYY-MM-DD or ""
+  evidence_urls: string;     // comma-separated or ""
+};
+
+const toBool = (v: any) => String(v ?? "").trim().toUpperCase() === "TRUE";
+const toNum  = (v: any) => {
+  const n = Number(String(v ?? "").trim());
+  return Number.isFinite(n) ? n : 0;
+};
+const t     = (v: any) => String(v ?? "").replace(/\s+$/g,"").trim(); // trim + drop trailing newline
+
+export async function getLeaderboard(): Promise<LiveItem[]> {
+  const CLIENT_EMAIL = process.env.GOOGLE_SHEETS_CLIENT_EMAIL || "";
+  const PRIVATE_KEY  = (process.env.GOOGLE_SHEETS_PRIVATE_KEY || "").replace(/\n/g, "\n").includes("\n")
+                       ? (process.env.GOOGLE_SHEETS_PRIVATE_KEY || "").replace(/\n/g, "\n").replace(/\\n/g, "\n").replace(/\n/g, "\n")
+                       : (process.env.GOOGLE_SHEETS_PRIVATE_KEY || "");
+  const SHEET_ID     = process.env.GOOGLE_SHEETS_SHEET_ID || "";
+  const TAB_NAME     = process.env.GOOGLE_SHEETS_TAB_NAME || "Leaderboard";
+
+  if (!CLIENT_EMAIL || !PRIVATE_KEY || !SHEET_ID) {
+    throw new Error("env_missing");
+  }
+
+  const jwt = new google.auth.JWT({
+    email: CLIENT_EMAIL,
+    key: PRIVATE_KEY,
+    scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+  });
+  const sheets = google.sheets({ version: "v4", auth: jwt });
+
+  // Read data rows only
+  const range = `${TAB_NAME}!A2:I`; // A: slug, B: title, C: los, D: mou, E: fera, F: meetings_count, G: meetings_30d, H: last_update_iso, I: evidence_urls
+  const { data } = await sheets.spreadsheets.values.get({ spreadsheetId: SHEET_ID, range });
+  const rows = data.values || [];
+
+  return rows.map((r) => {
+    const [
+      slug, title, los, mou, fera,
+      meetings_count, meetings_30d, last_update_iso, evidence_urls
+    ] = r;
+
+    return {
+      slug: t(slug),
+      title: t(title),
+      los_signed: toBool(los),
+      mou_signed: toBool(mou),
+      fera_signed: toBool(fera),
+      meetings_count: toNum(meetings_count),
+      meetings_30d: toNum(meetings_30d),
+      last_update_iso: t(last_update_iso),
+      evidence_urls: t(evidence_urls),
+    };
+  }).filter(x => x.slug);
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@heroicons/react": "^2.0.18",
         "@svg-maps/nigeria": "^1.0.0",
         "embla-carousel-react": "^8.6.0",
+        "googleapis": "^156.0.0",
         "lucide-react": "^0.539.0",
         "next": "14.0.1",
         "react": "^18",
@@ -1022,6 +1023,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1378,6 +1388,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1448,6 +1487,12 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -1482,7 +1527,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1496,7 +1540,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -1689,6 +1732,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -1747,7 +1799,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1848,7 +1899,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -1865,6 +1915,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.199",
@@ -1981,7 +2040,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1991,7 +2049,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2029,7 +2086,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2555,6 +2611,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2614,6 +2676,29 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2714,6 +2799,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -2754,7 +2851,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2791,11 +2887,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2820,7 +2943,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2956,11 +3078,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.2.1.tgz",
+      "integrity": "sha512-HMxFl2NfeHYnaL1HoRIN1XgorKS+6CDaM+z9LSSN+i/nKDDL4KFFEWogMXu7jV4HZQy2MsxpY+wA5XIf3w410A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "156.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-156.0.0.tgz",
+      "integrity": "sha512-Th401jKVdtrIaAc/b5iv8dfNVN2O7EgU/32Zvb2zxK3hiRrBU8hNbF7wMmOAEsvqnEKssq6XlXMaCBKazrvakw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.0.tgz",
+      "integrity": "sha512-66if47It7y+Sab3HMkwEXx1kCq9qUC9px8ZXoj1CMrmLmUw81GpbnsNlXnlyZyGbGPGcj+tDD9XsZ23m7GLaJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2981,6 +3158,19 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -3038,7 +3228,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3067,13 +3256,25 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ignore": {
@@ -3658,6 +3859,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3706,6 +3916,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -3827,7 +4058,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3894,7 +4124,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4024,6 +4253,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -4074,7 +4341,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4545,6 +4811,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4786,6 +5067,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -4919,7 +5220,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4939,7 +5239,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4956,7 +5255,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4975,7 +5273,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5839,6 +6136,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5857,6 +6160,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@heroicons/react": "^2.0.18",
     "@svg-maps/nigeria": "^1.0.0",
     "embla-carousel-react": "^8.6.0",
+    "googleapis": "^156.0.0",
     "lucide-react": "^0.539.0",
     "next": "14.0.1",
     "react": "^18",

--- a/pages/api/leaderboard/index.ts
+++ b/pages/api/leaderboard/index.ts
@@ -1,0 +1,16 @@
+export const runtime = "nodejs";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getLeaderboard } from "@/lib/leaderboard";
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const items = await getLeaderboard();
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("CDN-Cache-Control", "no-store");
+    res.setHeader("Vercel-CDN-Cache-Control", "no-store");
+    res.status(200).json({ ok: true, items, version: "v2-live" });
+  } catch (e: any) {
+    res.status(500).json({ ok: false, error: e?.message || "unknown_error" });
+  }
+}
+

--- a/pages/api/leaderboard/raw.ts
+++ b/pages/api/leaderboard/raw.ts
@@ -1,0 +1,20 @@
+export const runtime = "nodejs";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { google } from "googleapis";
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const email = process.env.GOOGLE_SHEETS_CLIENT_EMAIL || "";
+    const key   = (process.env.GOOGLE_SHEETS_PRIVATE_KEY || "").replace(/\n/g, "\n");
+    const id    = process.env.GOOGLE_SHEETS_SHEET_ID || "";
+    const tab   = process.env.GOOGLE_SHEETS_TAB_NAME || "Leaderboard";
+    const jwt = new google.auth.JWT({ email, key, scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"] });
+    const sheets = google.sheets({ version: "v4", auth: jwt });
+    const { data } = await sheets.spreadsheets.values.get({ spreadsheetId: id, range: `${tab}!A1:I10` });
+    res.setHeader("Cache-Control", "no-store");
+    res.status(200).json({ ok: true, sample: data.values || [] });
+  } catch (e: any) {
+    res.status(500).json({ ok:false, error: e?.message || "unknown_error" });
+  }
+}
+

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import StateCard from "@/components/StateCard";
 import Leaderboard from "@/components/Leaderboard";
 import { projects } from "@/data/projects";
+import { getLeaderboard } from "@/lib/leaderboard";
 
-export default function ProjectsPage() {
+export default function ProjectsPage({ live }: { live: any[] }) {
   return (
     <main className="max-w-6xl mx-auto p-6 space-y-6">
       <header className="space-y-2">
@@ -11,7 +12,7 @@ export default function ProjectsPage() {
         <p className="text-muted-foreground">Active and upcoming state engagements.</p>
       </header>
 
-      <Leaderboard items={projects as any} />
+      <Leaderboard items={live} />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {projects.map((p) => (
@@ -21,3 +22,13 @@ export default function ProjectsPage() {
     </main>
   );
 }
+
+export async function getServerSideProps() {
+  try {
+    const live = await getLeaderboard();
+    return { props: { live } };
+  } catch {
+    return { props: { live: [] } };
+  }
+}
+


### PR DESCRIPTION
## Summary
- replace Shared Sheets helper with strict live shape and data coercion
- expose live-only leaderboard API and raw debug endpoint
- show minimal 3-metric live leaderboard UI and fetch server-side on projects page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `git push -u origin codex/leaderboard-live-schema-fix` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_689db7ebc15c83318a1ed50522eee4c4