### PR TITLE
Refine useFlip hook typing

### DIFF
--- a/hooks/useFlip.ts
+++ b/hooks/useFlip.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 
-const useFlip = (initial = false) => {
-  const [isFlipped, setIsFlipped] = useState(initial);
+const useFlip = (initial: boolean = false) => {
+  const [isFlipped, setIsFlipped] = useState<boolean>(initial);
 
-  const toggle = () => setIsFlipped(!isFlipped);
+  const toggle = () => setIsFlipped((f) => !f);
 
-  return [isFlipped, toggle];
+  return [isFlipped, toggle] as const;
 };
 
 export default useFlip;


### PR DESCRIPTION
## Summary
- add explicit boolean typing to `useState` in `useFlip`
- update toggle to functional state setter
- return typed tuple using `as const`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f9460ed048331b09cd3ca038f4480