### PR TITLE
chore: remove redundant tailwind import

### DIFF
--- a/components/TypewriterText.tsx
+++ b/components/TypewriterText.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Typewriter from 'typewriter-effect';
-import 'tailwindcss/tailwind.css';
 
 const TypewriterText = () => {
   return (


### PR DESCRIPTION
## Summary
- remove tailwindcss import from TypewriterText component relying on global styles instead

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fe823ae888331bb9f1682c4ba6bda