### PR TITLE
chore: use Next Image in gallery carousel

### DIFF
--- a/components/GalleryCarousel.tsx
+++ b/components/GalleryCarousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import Image from "next/image";
 import {
   Carousel,
   CarouselContent,
@@ -20,11 +21,14 @@ export default function GalleryCarousel({ images }: GalleryCarouselProps) {
         <CarouselContent>
           {images.map((img, i) => (
             <CarouselItem key={i} className="basis-full">
-              <img
-                src={img.src}
-                alt={img.alt}
-                className="w-full h-64 md:h-80 lg:h-96 object-cover rounded-2xl border bg-muted"
-              />
+              <div className="relative w-full h-64 md:h-80 lg:h-96">
+                <Image
+                  src={img.src}
+                  alt={img.alt}
+                  className="object-cover rounded-2xl border bg-muted"
+                  fill
+                />
+              </div>
             </CarouselItem>
           ))}
         </CarouselContent>


### PR DESCRIPTION
## Summary
- replace `<img>` tags with Next.js `<Image>` in gallery carousel
- ensure responsive sizing with fill and existing styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fee5602f48331b84cee0ed91a208a