### PR TITLE
chore: convert Tailwind config to ESM

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
@@ -12,4 +13,6 @@ module.exports = {
     extend: {},
   },
   plugins: [],
-}
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- convert `tailwind.config.ts` to ESM with typed config and default export
- ensure Tailwind config ends with a newline

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0142e5270833198ae295f652d7a1e