### PR TITLE
feat: move Nigeria pages and add redirects

### DIFF
--- a/components/StateCard.tsx
+++ b/components/StateCard.tsx
@@ -25,7 +25,7 @@ const StateCard: React.FC<StateCardProps> = ({
   const safeTags = Array.isArray(tags) ? tags.filter(Boolean) : [];
   return (
     <Link
-      href={`/states/${slug}`}
+      href={`/projects/nigeria/states/${slug}`}
       className="group block focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 rounded-2xl"
     >
       <article

--- a/components/StateDetailsCard.tsx
+++ b/components/StateDetailsCard.tsx
@@ -99,7 +99,7 @@ export default function StateDetailsCard({ slug }: { slug: string }) {
       <div className="px-6 pb-6 pt-3 border-t bg-gradient-to-b from-transparent to-muted/30">
         <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-end">
           <Link
-            href="/country"
+            href="/projects/nigeria"
             className="inline-flex items-center rounded-xl border px-4 py-2 text-sm font-medium hover:bg-accent"
           >
             See National Map

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,21 @@ const nextConfig = {
   async redirects() {
     return [
       { source: '/about', destination: '/about-us', permanent: true },
+      {
+        source: '/states/:slug',
+        destination: '/projects/nigeria/states/:slug',
+        permanent: true,
+      },
+      {
+        source: '/states/:slug/facts',
+        destination: '/projects/nigeria/states/:slug/facts',
+        permanent: true,
+      },
+      {
+        source: '/country',
+        destination: '/projects/nigeria',
+        permanent: true,
+      },
     ];
   },
   // ... other configurations you might have

--- a/pages/projects/nigeria/index.tsx
+++ b/pages/projects/nigeria/index.tsx
@@ -15,7 +15,9 @@ export default function CountryPage() {
     return pool.filter((slug) => STATES[slug].name.toLowerCase().includes(needle));
   }, [q, pool]);
 
-  const links = Object.fromEntries(filtered.map((slug) => [slug, `/states/${slug}`]));
+  const links = Object.fromEntries(
+    filtered.map((slug) => [slug, `/projects/nigeria/states/${slug}`])
+  );
   const active = ACTIVE;
 
   return (
@@ -26,6 +28,10 @@ export default function CountryPage() {
           name="description"
           content="States we're actively engaging in Nigeria."
         />
+        <link
+          rel="canonical"
+          href={`${process.env.NEXT_PUBLIC_SITE_URL || ""}/projects/nigeria`}
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
@@ -34,7 +40,7 @@ export default function CountryPage() {
               "@type": "BreadcrumbList",
               itemListElement: [
                 { "@type": "ListItem", position: 1, name: "Home", item: "/" },
-                { "@type": "ListItem", position: 2, name: "Nigeria Overview", item: "/country" },
+                { "@type": "ListItem", position: 2, name: "Nigeria Overview", item: "/projects/nigeria" },
               ],
             }),
           }}
@@ -91,7 +97,7 @@ export default function CountryPage() {
               {filtered.map((slug) => (
                 <Link
                   key={slug}
-                  href={`/states/${slug}`}
+                  href={`/projects/nigeria/states/${slug}`}
                   className="flex items-center justify-between rounded-xl border px-3 py-2 hover:bg-muted min-h-12"
                 >
                   <div className="text-sm">

--- a/pages/projects/nigeria/states/[slug].tsx
+++ b/pages/projects/nigeria/states/[slug].tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import Link from "next/link";
+import Head from "next/head";
 import StateDetailsCarousel from "@/components/StateDetailsCarousel";
 
 const ORDER = ["niger", "kwara", "plateau"];
@@ -8,9 +9,18 @@ export default function StatePage() {
   const router = useRouter();
   const { slug } = router.query;
   const startIndex = typeof slug === "string" ? ORDER.indexOf(slug) : 0;
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "";
+  const canonical =
+    typeof slug === "string"
+      ? `${baseUrl}/projects/nigeria/states/${slug}`
+      : `${baseUrl}/projects/nigeria/states`;
 
   return (
     <>
+      <Head>
+        <link rel="canonical" href={canonical} />
+        <title>State Details | Article6</title>
+      </Head>
       <header className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-6">
         <Link
           href="/projects"

--- a/pages/projects/nigeria/states/[slug]/facts.tsx
+++ b/pages/projects/nigeria/states/[slug]/facts.tsx
@@ -1,0 +1,26 @@
+import { useRouter } from "next/router";
+import Head from "next/head";
+
+export default function StateFactsPage() {
+  const { slug } = useRouter().query;
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "";
+  const canonical =
+    typeof slug === "string"
+      ? `${baseUrl}/projects/nigeria/states/${slug}/facts`
+      : `${baseUrl}/projects/nigeria/states/facts`;
+
+  return (
+    <>
+      <Head>
+        <link rel="canonical" href={canonical} />
+        <title>State Facts | Article6</title>
+      </Head>
+      <main className="max-w-6xl mx-auto p-6 space-y-4">
+        <h1 className="text-3xl font-semibold tracking-tight">
+          {typeof slug === "string" ? slug.charAt(0).toUpperCase() + slug.slice(1) : "State"} Facts
+        </h1>
+        <p className="text-muted-foreground">More information coming soon.</p>
+      </main>
+    </>
+  );
+}

--- a/pages/sitemap.xml.tsx
+++ b/pages/sitemap.xml.tsx
@@ -1,0 +1,32 @@
+import { GetServerSideProps } from "next";
+import { states } from "@/data/states";
+
+function generateSiteMap(baseUrl: string) {
+  const urls = [
+    `${baseUrl}/projects/nigeria`,
+    ...states.flatMap((s) => [
+      `${baseUrl}/projects/nigeria/states/${s.slug}`,
+      `${baseUrl}/projects/nigeria/states/${s.slug}/facts`,
+    ]),
+  ];
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls
+    .map((url) => `  <url><loc>${url}</loc></url>`)
+    .join("\n")}\n</urlset>`;
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ res, req }) => {
+  const proto = req.headers["x-forwarded-proto"] || "https";
+  const host = req.headers.host || "";
+  const sitemap = generateSiteMap(`${proto}://${host}`);
+
+  res.setHeader("Content-Type", "text/xml");
+  res.write(sitemap);
+  res.end();
+
+  return { props: {} };
+};
+
+export default function SiteMap() {
+  return null;
+}

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -2,7 +2,7 @@
 export const navigationLinks = [
   { href: '/technology', label: 'Technology' },
   { href: '/projects', label: 'Projects' },
-  { href: '/country', label: 'Countries' },
+  { href: '/projects/nigeria', label: 'Nigeria' },
   { href: '/about-us', label: 'About Us' },
   { href: '/contact', label: 'Contact' }
 ];


### PR DESCRIPTION
## Summary
- move Nigeria country and state pages under /projects
- add 301 redirects and dynamic sitemap for new paths
- update navigation and links to use new /projects/nigeria routes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a034f39594833188c61c6a7ccbd5e7