### PR TITLE
fix nigeria map routing by clicked state

### DIFF
--- a/components/NigeriaMap.tsx
+++ b/components/NigeriaMap.tsx
@@ -9,6 +9,9 @@ type NigeriaData = {
   locations: { id: string; name: string; path: string }[];
 };
 
+type Slug = (typeof SLUGS)[number];
+type Division = { slug: Slug; inPipeline: boolean };
+
 const ALIASES: Record<string, string> = {
   nassarawa: "nasarawa",
 };
@@ -32,7 +35,7 @@ export default function NigeriaMap({
   const [tip, setTip] = useState<{ x: number; y: number; text: string } | null>(null);
 
   const COUNTRY_BASE = "/projects/nigeria";
-  const divisions = useMemo(
+  const divisions = useMemo<Division[]>(
     () =>
       SLUGS.map((slug) => ({
         slug,
@@ -41,7 +44,7 @@ export default function NigeriaMap({
     []
   );
   const divisionMap = useMemo(
-    () => new Map(divisions.map((d) => [d.slug, d])),
+    () => new Map<Slug, Division>(divisions.map((d) => [d.slug, d])),
     [divisions]
   );
 
@@ -50,7 +53,7 @@ export default function NigeriaMap({
     () =>
       data.locations.map((loc) => ({
         ...loc,
-        properties: { slug: norm(loc.id) },
+        properties: { slug: norm(loc.id) as Slug },
       })),
     [data]
   );
@@ -58,7 +61,7 @@ export default function NigeriaMap({
   const scaleX = 1000 / vbW;
   const scaleY = 1000 / vbH;
 
-  const activeSet = useMemo(() => new Set(active.map((a) => norm(a))), [active]);
+  const activeSet = useMemo(() => new Set(active.map((a) => norm(a) as Slug)), [active]);
 
   const onMove = (e: React.MouseEvent) => {
     if (!tip || !svgRef.current) return;
@@ -66,7 +69,7 @@ export default function NigeriaMap({
     setTip({ ...tip, x: e.clientX - r.left + 12, y: e.clientY - r.top + 12 });
   };
 
-  const onClickFeature = (feature: { properties?: { slug?: string } }) => {
+  const onClickFeature = (feature: { properties?: { slug?: Slug } }) => {
     const slug = feature?.properties?.slug;
     if (!slug) return console.warn("Missing slug for clicked feature", feature);
     const entry = divisionMap.get(slug);

--- a/pages/projects/nigeria/states/[slug]/facts.tsx
+++ b/pages/projects/nigeria/states/[slug]/facts.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from "next/router";
+import Link from "next/link";
+
+export default function NigeriaStateFactsPage() {
+  const { slug } = useRouter().query;
+  const name = typeof slug === "string" ? slug : "";
+  return (
+    <main className="max-w-6xl mx-auto p-6 space-y-4">
+      <header>
+        <Link
+          href="/projects"
+          className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
+        >
+          <span className="mr-2">←</span> Back to Projects
+        </Link>
+      </header>
+      <h1 className="text-2xl font-semibold capitalize">{name} Facts</h1>
+      <p className="text-muted-foreground">Coming soon.</p>
+    </main>
+  );
+}
+

--- a/pages/projects/nigeria/states/[slug]/index.tsx
+++ b/pages/projects/nigeria/states/[slug]/index.tsx
@@ -1,0 +1,31 @@
+import { useRouter } from "next/router";
+import Link from "next/link";
+import StateDetailsCarousel from "@/components/StateDetailsCarousel";
+
+const ORDER = ["niger", "kwara", "plateau"];
+
+export default function NigeriaStatePage() {
+  const router = useRouter();
+  const { slug } = router.query;
+  const startIndex = typeof slug === "string" ? ORDER.indexOf(slug) : 0;
+
+  return (
+    <>
+      <header className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-6">
+        <Link
+          href="/projects"
+          className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
+        >
+          <span className="mr-2">←</span> Back to Projects
+        </Link>
+      </header>
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 md:pt-20">
+        <StateDetailsCarousel
+          states={ORDER}
+          startIndex={startIndex >= 0 ? startIndex : 0}
+        />
+      </main>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- attach state slug to map features and route using clicked slug
- disable clicks for states missing metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a040d79a18833188336b4160d80c38