### PR TITLE
Add Nigeria state detail and facts pages

### DIFF
--- a/pages/projects/nigeria/states/[slug].tsx
+++ b/pages/projects/nigeria/states/[slug].tsx
@@ -1,0 +1,28 @@
+import { useRouter } from "next/router";
+import Link from "next/link";
+
+function titleCase(value: string): string {
+  return value
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export default function StateDetailPage() {
+  const router = useRouter();
+  const { slug } = router.query;
+  const title = typeof slug === "string" ? titleCase(slug) : "";
+
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">State: {title}</h1>
+      <Link
+        href="/contact"
+        className="inline-block rounded-md bg-blue-600 px-4 py-2 text-white"
+      >
+        Book an Expert
+      </Link>
+    </main>
+  );
+}
+

--- a/pages/projects/nigeria/states/[slug]/facts.tsx
+++ b/pages/projects/nigeria/states/[slug]/facts.tsx
@@ -1,0 +1,46 @@
+import { useRouter } from "next/router";
+import Link from "next/link";
+
+const FACTS: Record<string, string[]> = {
+  plateau: [
+    "Plateau is known for its scenic rock formations.",
+    "It hosts one of Nigeria's most diverse climates.",
+    "The state is a major producer of potatoes."
+  ]
+};
+
+function titleCase(value: string): string {
+  return value
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export default function StateFactsPage() {
+  const router = useRouter();
+  const { slug } = router.query;
+  const title = typeof slug === "string" ? titleCase(slug) : "";
+  const facts = typeof slug === "string" ? FACTS[slug] : undefined;
+
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Facts: {title}</h1>
+      {facts && facts.length > 0 ? (
+        <ul className="list-disc pl-6 space-y-1">
+          {facts.slice(0, 3).map((fact, idx) => (
+            <li key={idx}>{fact}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>Register your interest</p>
+      )}
+      <Link
+        href="/contact"
+        className="inline-block rounded-md bg-blue-600 px-4 py-2 text-white"
+      >
+        Book an Expert
+      </Link>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add dynamic Nigeria state detail page
- add state facts page with placeholder facts and CTA

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a046dbc934833188fea6623e7a41b6