### PR TITLE
Align project state links with map URLs

### DIFF
--- a/components/StateCard.tsx
+++ b/components/StateCard.tsx
@@ -10,6 +10,7 @@ interface StateCardProps {
   tags?: string[];
   updatedAt?: string;
   ctaLabel?: string;
+  href?: string;
 }
 
 const StateCard: React.FC<StateCardProps> = ({
@@ -21,11 +22,13 @@ const StateCard: React.FC<StateCardProps> = ({
   tags,
   updatedAt,
   ctaLabel,
+  href,
 }) => {
   const safeTags = Array.isArray(tags) ? tags.filter(Boolean) : [];
+  const link = href ?? `/states/${slug}`;
   return (
     <Link
-      href={`/states/${slug}`}
+      href={link}
       className="group block focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 rounded-2xl"
     >
       <article

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -82,7 +82,7 @@ export default function ProjectsPage({ live, cards, debug }: Props) {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {cards.map((p) => (
-          <StateCard key={p.slug} {...p} />
+          <StateCard key={p.slug} {...p} href={`/projects/nigeria/states/${p.slug}`} />
         ))}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- allow `StateCard` to accept a custom `href`
- use project-specific state links on the Projects page to match map navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a04db627d883318129181a9af5e34e