### PR TITLE
feat: add state facts and CTAs

### DIFF
--- a/components/FactCard.tsx
+++ b/components/FactCard.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+export default function FactCard({ text }: { text: string }) {
+  return (
+    <div className="rounded-2xl border bg-white/5 backdrop-blur p-4 shadow-sm">
+      {text}
+    </div>
+  );
+}

--- a/components/StateDetailsCard.tsx
+++ b/components/StateDetailsCard.tsx
@@ -104,12 +104,6 @@ export default function StateDetailsCard({ slug }: { slug: string }) {
           >
             See National Map
           </Link>
-          <Link
-            href="/contact"
-            className="inline-flex items-center rounded-xl bg-black text-white px-4 py-2 text-sm font-medium hover:opacity-90"
-          >
-            Request Brief
-          </Link>
         </div>
       </div>
     </div>

--- a/data/countries/nigeria.ts
+++ b/data/countries/nigeria.ts
@@ -1,0 +1,53 @@
+import { SLUGS, ACTIVE, toTitle } from "@/data/country";
+
+type Fact = { id?: string; text: string };
+export interface Division {
+  slug: string;
+  title: string;
+  inPipeline?: boolean;
+  facts?: Fact[];
+}
+
+const pipelineSlugs = new Set(ACTIVE);
+const baseDivisions: Division[] = SLUGS.map((slug) => ({
+  slug,
+  title: toTitle(slug),
+  inPipeline: pipelineSlugs.has(slug),
+}));
+
+export const nigeria = {
+  divisions: baseDivisions.map((d) => {
+    if (d.slug === "oyo") {
+      return {
+        ...d,
+        inPipeline: d.inPipeline ?? false,
+        facts: d.facts ?? [
+          { id: "capital", text: "Capital: Ibadan." },
+          { id: "created", text: "Created: 1976." },
+          { id: "note", text: "University of Ibadan (1948) is Nigeria’s oldest." },
+        ],
+      };
+    }
+    if (d.slug === "lagos") {
+      return {
+        ...d,
+        facts: d.facts ?? [
+          { text: "Capital: Ikeja." },
+          { text: "Created: 1967." },
+          { text: "Lagos was federal capital until 1991 and remains the commercial hub." },
+        ],
+      };
+    }
+    if (d.slug === "niger") {
+      return {
+        ...d,
+        facts: d.facts ?? [
+          { text: "Capital: Minna." },
+          { text: "Created: 1976." },
+          { text: "Hosts Kainji and Shiroro hydropower dams." },
+        ],
+      };
+    }
+    return d;
+  }),
+};

--- a/pages/states/[slug].tsx
+++ b/pages/states/[slug].tsx
@@ -1,23 +1,46 @@
 import { useRouter } from "next/router";
 import Link from "next/link";
 import StateDetailsCarousel from "@/components/StateDetailsCarousel";
+import { ACTIVE } from "@/data/country";
+import { nigeria } from "@/data/countries/nigeria";
 
-const ORDER = ["niger", "kwara", "plateau"];
+const ORDER = ACTIVE;
 
 export default function StatePage() {
   const router = useRouter();
   const { slug } = router.query;
+  const currentSlug = typeof slug === "string" ? slug : "";
   const startIndex = typeof slug === "string" ? ORDER.indexOf(slug) : 0;
+  const div = nigeria.divisions.find((d) => d.slug === currentSlug);
+  const hasFacts = (div?.facts?.length ?? 0) > 0;
 
   return (
     <>
       <header className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-6">
-        <Link
-          href="/projects"
-          className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
-        >
-          <span className="mr-2">←</span> Back to Projects
-        </Link>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <Link
+            href="/projects"
+            className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
+          >
+            <span className="mr-2">←</span> Back to Projects
+          </Link>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/contact"
+              className="inline-flex items-center rounded-xl border px-4 py-2 text-sm font-medium shadow-sm hover:shadow transition"
+            >
+              Book an Expert
+            </Link>
+            {hasFacts && (
+              <Link
+                href={`/states/${currentSlug}/facts`}
+                className="inline-flex items-center rounded-xl border px-4 py-2 text-sm font-medium hover:bg-white/5 transition"
+              >
+                Facts
+              </Link>
+            )}
+          </div>
+        </div>
       </header>
       <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 md:pt-20">
         <StateDetailsCarousel

--- a/pages/states/[slug]/facts.tsx
+++ b/pages/states/[slug]/facts.tsx
@@ -1,0 +1,52 @@
+import { GetStaticPaths, GetStaticProps } from "next";
+import Link from "next/link";
+import FactCard from "@/components/FactCard";
+import { nigeria } from "@/data/countries/nigeria";
+
+type Fact = { id?: string; text: string };
+type Props = { slug: string; title: string; facts: Fact[] };
+
+export default function FactsPage({ slug, title, facts }: Props) {
+  const hasFacts = facts.length > 0;
+  return (
+    <main className="max-w-6xl mx-auto p-6 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">
+          {hasFacts ? `Did you know about ${title}?` : `${title} — Register your interest`}
+        </h1>
+        {!hasFacts && (
+          <p className="text-muted-foreground">
+            This state isn’t in our active pipeline yet. Explore opportunities with our team.
+          </p>
+        )}
+      </header>
+
+      {hasFacts && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {facts.map((f, i) => (
+            <FactCard key={f.id ?? i} text={f.text} />
+          ))}
+        </div>
+      )}
+
+      <div className="pt-2">
+        <Link href="/contact" className="inline-flex items-center rounded-xl border px-4 py-2 shadow-sm hover:shadow transition">
+          Book an Expert
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const slugs = nigeria.divisions.map((d) => d.slug);
+  return { paths: slugs.map((slug) => ({ params: { slug } })), fallback: "blocking" };
+};
+
+export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+  const slug = String(params?.slug || "");
+  const div = nigeria.divisions.find((d) => d.slug === slug);
+  if (!div) return { notFound: true };
+  const facts = (div.facts ?? []).map((f, i) => ({ id: f.id ?? String(i), text: f.text }));
+  return { props: { slug, title: div.title, facts }, revalidate: 300 };
+};


### PR DESCRIPTION
## Summary
- add Nigeria divisions dataset with early state facts
- expose facts via new `/states/[slug]/facts` page and `FactCard`
- update state detail page CTA to "Book an Expert" with optional Facts link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0518f0d8883319d56f6d713700aec