### PR TITLE
feat(states): reusable state layout + facts view (coming soon) + conditional carousel

### DIFF
--- a/components/state/StateBodyFacts.tsx
+++ b/components/state/StateBodyFacts.tsx
@@ -1,0 +1,31 @@
+interface StateBodyFactsProps {
+  stateName: string;
+  facts?: string[];
+}
+
+export default function StateBodyFacts({ stateName, facts }: StateBodyFactsProps) {
+  if (!facts || facts.length === 0) {
+    return (
+      <div className="rounded-xl border bg-muted/30 p-6 text-center space-y-2">
+        <h2 className="text-xl font-semibold">Coming soon</h2>
+        <p className="text-sm text-muted-foreground">
+          We&apos;re preparing verified facts for {stateName}. Talk to our team meanwhile.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      {facts.map((fact, i) => (
+        <div
+          key={i}
+          className="rounded-xl border bg-white/60 backdrop-blur p-4 shadow-sm"
+        >
+          <p className="text-sm leading-relaxed">{fact}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/components/state/StateBodyProject.tsx
+++ b/components/state/StateBodyProject.tsx
@@ -1,0 +1,60 @@
+interface Doc {
+  label: string;
+  url: string;
+}
+
+interface StateBodyProjectProps {
+  doneSoFar: string[];
+  nextSteps: string[];
+  docs?: Doc[];
+}
+
+export default function StateBodyProject({
+  doneSoFar,
+  nextSteps,
+  docs,
+}: StateBodyProjectProps) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <h2 className="text-xl font-semibold">What we&apos;ve done so far</h2>
+        <ul className="list-disc pl-5 space-y-2 text-sm leading-relaxed">
+          {doneSoFar.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </div>
+
+      {nextSteps.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Next steps</h2>
+          <ol className="list-decimal pl-5 space-y-2 text-sm leading-relaxed">
+            {nextSteps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </div>
+      )}
+
+      {docs && docs.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Documents shared</h2>
+          <div className="flex flex-wrap gap-2">
+            {docs.map((doc) => (
+              <a
+                key={doc.url}
+                href={doc.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-3 py-1 border rounded-full text-sm"
+              >
+                {doc.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/state/StateCarousel.tsx
+++ b/components/state/StateCarousel.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Image from "next/image";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
+
+interface StateCarouselProps {
+  images?: string[];
+}
+
+export default function StateCarousel({ images }: StateCarouselProps) {
+  if (!images || images.length === 0) return null;
+
+  return (
+    <div className="relative">
+      <Carousel className="w-full">
+        <CarouselContent>
+          {images.map((src, i) => (
+            <CarouselItem key={i} className="basis-full">
+              <div className="relative w-full h-64 md:h-80 lg:h-96">
+                <Image
+                  src={src}
+                  alt={`Image ${i + 1}`}
+                  className="object-cover rounded-2xl border bg-muted"
+                  fill
+                />
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+    </div>
+  );
+}
+

--- a/components/state/StateLayout.tsx
+++ b/components/state/StateLayout.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+
+interface StateLayoutProps {
+  title: string;
+  subtitle?: string;
+  stagePill?: string;
+  backHref?: string;
+  primaryCtaHref?: string;
+  primaryCtaLabel?: string;
+  rightNav?: ReactNode;
+  tertiaryCtaHref?: string;
+  tertiaryCtaLabel?: string;
+  children: ReactNode;
+}
+
+export default function StateLayout({
+  title,
+  subtitle,
+  stagePill,
+  backHref = "/projects/nigeria",
+  primaryCtaHref = "/contact",
+  primaryCtaLabel = "Book an Expert",
+  rightNav,
+  tertiaryCtaHref,
+  tertiaryCtaLabel = "Facts",
+  children,
+}: StateLayoutProps) {
+  const allChildren = Array.isArray(children)
+    ? children
+    : [children];
+  const sidebar = allChildren[allChildren.length - 1];
+  const mainChildren = allChildren.slice(0, -1);
+  const backLabel =
+    backHref === "/country" ? "Back to Country" : "Back to Projects";
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 space-y-6">
+      <header className="space-y-6">
+        <Link
+          href={backHref}
+          className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
+        >
+          <span className="mr-2">←</span> {backLabel}
+        </Link>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+            {subtitle && (
+              <p className="text-muted-foreground mt-1">{subtitle}</p>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {stagePill && (
+              <span className="inline-flex items-center rounded-full px-3 py-1 text-sm font-medium bg-gray-100 text-gray-800">
+                {stagePill}
+              </span>
+            )}
+            {rightNav}
+          </div>
+        </div>
+      </header>
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <section className="lg:col-span-2 space-y-6">{mainChildren}</section>
+        <aside className="lg:col-span-1">{sidebar}</aside>
+      </div>
+      <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-end border-t pt-6">
+        {tertiaryCtaHref && (
+          <Link
+            href={tertiaryCtaHref}
+            className="text-sm underline sm:mr-auto"
+          >
+            {tertiaryCtaLabel}
+          </Link>
+        )}
+        <Link
+          href="/country"
+          className="inline-flex items-center rounded-xl border px-4 py-2 text-sm font-medium hover:bg-accent"
+        >
+          See National Map
+        </Link>
+        <Link
+          href={primaryCtaHref}
+          className="inline-flex items-center rounded-xl bg-black text-white px-4 py-2 text-sm font-medium hover:opacity-90"
+        >
+          {primaryCtaLabel}
+        </Link>
+      </div>
+    </div>
+  );
+}
+

--- a/components/state/StateSidebar.tsx
+++ b/components/state/StateSidebar.tsx
@@ -1,0 +1,49 @@
+interface Contact {
+  name: string;
+  title?: string;
+}
+
+interface StateSidebarProps {
+  contacts?: Contact[];
+  focusAreas?: string[];
+}
+
+export default function StateSidebar({
+  contacts = [],
+  focusAreas = [],
+}: StateSidebarProps) {
+  if (contacts.length === 0 && focusAreas.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border bg-muted/30 p-4 sticky top-20 space-y-4">
+      {contacts.length > 0 && (
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Contacts</p>
+          <div className="mt-2 space-y-2 text-sm">
+            {contacts.map((c) => (
+              <div key={c.name}>
+                <div>{c.name}</div>
+                {c.title && (
+                  <div className="text-xs text-muted-foreground">{c.title}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {focusAreas.length > 0 && (
+        <div className={contacts.length > 0 ? "border-t pt-4" : ""}>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Focus Areas</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {focusAreas.map((f) => (
+              <span key={f} className="px-2 py-1 rounded-lg border text-xs">
+                {f}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/data/countries/nigeria.ts
+++ b/data/countries/nigeria.ts
@@ -1,0 +1,85 @@
+export interface Division {
+  slug: string;
+  title: string;
+  subtitle?: string;
+  stagePill?: string;
+  images?: string[];
+  contacts?: { name: string; title?: string }[];
+  focus?: string[];
+  docs?: { label: string; url: string }[];
+  doneSoFar?: string[];
+  nextSteps?: string[];
+  facts?: string[];
+}
+
+export const divisions: Record<string, Division> = {
+  niger: {
+    slug: "niger",
+    title: "Niger State",
+    subtitle: "The Power State",
+    stagePill: "In Discussion",
+    images: [
+      "https://ik.imagekit.io/tzublgy5d/Article6/Niger%20State/Niger%20meeting%202.jpeg",
+      "https://ik.imagekit.io/tzublgy5d/Article6/Niger%20State/Niger%20meeting.jpeg",
+    ],
+    contacts: [
+      {
+        name: "Dr. Matthew Ahmed",
+        title: "Permanent Secretary, Ministry of Agriculture & Food Security",
+      },
+    ],
+    focus: ["Rice (AWD)", "Forestry MRV"],
+    docs: [
+      { label: "EOI (Niger)", url: "/docs/niger_eoi.pdf" },
+      { label: "Proposal (Niger)", url: "/docs/niger_proposal.pdf" },
+      { label: "MOU (Niger)", url: "/docs/niger_mou.pdf" },
+      { label: "LOS (Niger)", url: "/docs/niger_los.pdf" },
+    ],
+    doneSoFar: [
+      "Intro call with Dr. Matthew Ahmed (Perm Sec) – proposal discussed",
+      "EOI, Proposal, MOU, LOS sent for review",
+      "Drinks with Niger State delegation in Abuja for alignment",
+    ],
+    nextSteps: [
+      "Finalize MOU with state leadership",
+      "Plan field pilot in rice paddies",
+    ],
+    facts: [],
+  },
+  plateau: {
+    slug: "plateau",
+    title: "Plateau State",
+    subtitle: "Home of Peace and Tourism",
+    stagePill: "Early Engagement",
+    contacts: [
+      {
+        name: "Mr. Yakubu Nuhu",
+        title: "Special Adviser to the Governor on Carbon",
+      },
+    ],
+    focus: ["Rice (AWD)", "Forestry MRV"],
+    docs: [
+      { label: "EOI (Plateau)", url: "/docs/plateau_eoi.pdf" },
+      { label: "Proposal (Plateau)", url: "/docs/plateau_proposal.pdf" },
+      { label: "MOU (Plateau)", url: "/docs/plateau_mou.pdf" },
+      { label: "LOS (Plateau)", url: "/docs/plateau_los.pdf" },
+    ],
+    doneSoFar: [
+      "4-document pack shared via advisor (EOI, Proposal, MOU, LOS)",
+      "SA on Carbon Credit reviewing; next meeting to be scheduled",
+    ],
+    nextSteps: ["Schedule review meeting", "Plan site visit"],
+    facts: [],
+  },
+  oyo: {
+    slug: "oyo",
+    title: "Oyo State",
+    subtitle: "The Pace Setter State",
+    facts: [],
+  },
+};
+
+export function getDivision(slug: string): Division | undefined {
+  return divisions[slug];
+}
+

--- a/pages/states/[slug].tsx
+++ b/pages/states/[slug].tsx
@@ -1,31 +1,43 @@
 import { useRouter } from "next/router";
-import Link from "next/link";
-import StateDetailsCarousel from "@/components/StateDetailsCarousel";
+import StateLayout from "@/components/state/StateLayout";
+import StateCarousel from "@/components/state/StateCarousel";
+import StateSidebar from "@/components/state/StateSidebar";
+import StateBodyProject from "@/components/state/StateBodyProject";
+import { getDivision } from "@/data/countries/nigeria";
 
-const ORDER = ["niger", "kwara", "plateau"];
-
-export default function StatePage() {
+export default function StateProjectPage() {
   const router = useRouter();
   const { slug } = router.query;
-  const startIndex = typeof slug === "string" ? ORDER.indexOf(slug) : 0;
+
+  if (typeof slug !== "string") return null;
+  const division = getDivision(slug);
+  if (!division) return null;
+
+  const {
+    title,
+    subtitle,
+    stagePill,
+    images,
+    contacts,
+    focus,
+    docs,
+    doneSoFar = [],
+    nextSteps = [],
+    facts,
+  } = division;
 
   return (
-    <>
-      <header className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-6">
-        <Link
-          href="/projects"
-          className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
-        >
-          <span className="mr-2">←</span> Back to Projects
-        </Link>
-      </header>
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 md:pt-20">
-        <StateDetailsCarousel
-          states={ORDER}
-          startIndex={startIndex >= 0 ? startIndex : 0}
-        />
-      </main>
-    </>
+    <StateLayout
+      title={title}
+      subtitle={subtitle}
+      stagePill={stagePill}
+      backHref="/projects/nigeria"
+      tertiaryCtaHref={facts && facts.length > 0 ? `/states/${slug}/facts` : undefined}
+    >
+      {images && images.length > 0 && <StateCarousel images={images} />}
+      <StateBodyProject doneSoFar={doneSoFar} nextSteps={nextSteps} docs={docs} />
+      <StateSidebar contacts={contacts} focusAreas={focus} />
+    </StateLayout>
   );
 }
 

--- a/pages/states/[slug]/facts.tsx
+++ b/pages/states/[slug]/facts.tsx
@@ -1,0 +1,29 @@
+import { useRouter } from "next/router";
+import StateLayout from "@/components/state/StateLayout";
+import StateSidebar from "@/components/state/StateSidebar";
+import StateBodyFacts from "@/components/state/StateBodyFacts";
+import { getDivision } from "@/data/countries/nigeria";
+
+export default function StateFactsPage() {
+  const router = useRouter();
+  const { slug } = router.query;
+
+  if (typeof slug !== "string") return null;
+  const division = getDivision(slug);
+  if (!division) return null;
+
+  const { title, stagePill, contacts, focus, facts } = division;
+
+  return (
+    <StateLayout
+      title={title}
+      subtitle="Did you know?"
+      stagePill={stagePill}
+      backHref="/projects/nigeria"
+    >
+      <StateBodyFacts stateName={title} facts={facts} />
+      <StateSidebar contacts={contacts} focusAreas={focus} />
+    </StateLayout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract shared `StateLayout` with consistent CTAs and optional tertiary "Facts" link
- add `StateCarousel`, `StateBodyProject`, `StateBodyFacts`, and `StateSidebar` components
- wire state pages and sample Nigeria data to new layout; add facts route with coming-soon card

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a06409e7b0833187f76a4870f8b555