### PR TITLE
Add anchor links for Nigeria map states

### DIFF
--- a/components/NigeriaMap.tsx
+++ b/components/NigeriaMap.tsx
@@ -205,7 +205,7 @@ export default function NigeriaMap({
               } as React.SVGProps<SVGPathElement>;
 
               return (
-                <a key={slug ?? loc.id} xlinkHref={href ?? undefined}>
+                <a key={slug ?? loc.id} href={href ?? undefined}>
                   <path {...pathProps} />
                 </a>
               );

--- a/components/NigeriaMap.tsx
+++ b/components/NigeriaMap.tsx
@@ -95,17 +95,6 @@ export default function NigeriaMap({
     setCoords({ x, y });
   };
 
-  const onClickFeature = (feature: { properties?: { slug?: Slug } }) => {
-    const slug = feature?.properties?.slug;
-    if (!slug) return console.warn("Missing slug for clicked feature", feature);
-    const entry = divisionMap.get(slug);
-    if (!entry) return console.warn("No data for slug:", slug);
-    const href = entry.inPipeline
-      ? `${COUNTRY_BASE}/states/${slug}`
-      : `${COUNTRY_BASE}/states/${slug}/facts`;
-    router.push(href);
-  };
-
     return (
       <div className="relative w-full">
         <svg
@@ -134,6 +123,11 @@ export default function NigeriaMap({
                 ? "#FCD34D"
                 : "#22C55E";
               const entry = slug ? divisionMap.get(slug) : undefined;
+              const href = entry
+                ? entry.inPipeline
+                  ? `${COUNTRY_BASE}/states/${slug}`
+                  : `${COUNTRY_BASE}/states/${slug}/facts`
+                : undefined;
 
               const handleEnter = valid
                 ? (e: React.MouseEvent<SVGPathElement>) => {
@@ -168,7 +162,8 @@ export default function NigeriaMap({
               const handleClick = entry
                 ? (e: React.MouseEvent<SVGPathElement>) => {
                     e.stopPropagation();
-                    onClickFeature(loc);
+                    e.preventDefault();
+                    if (href) router.push(href);
                   }
                 : valid
                 ? (e: React.MouseEvent<SVGPathElement>) => {
@@ -209,7 +204,11 @@ export default function NigeriaMap({
                 "aria-label": title ?? undefined,
               } as React.SVGProps<SVGPathElement>;
 
-              return <path key={slug ?? loc.id} {...pathProps} />;
+              return (
+                <a key={slug ?? loc.id} xlinkHref={href ?? undefined}>
+                  <path {...pathProps} />
+                </a>
+              );
             })}
           </g>
       </svg>

--- a/components/NigeriaMap.tsx
+++ b/components/NigeriaMap.tsx
@@ -108,7 +108,7 @@ export default function NigeriaMap({
           <g transform={`scale(${scaleX} ${scaleY})`}>
             {locations.map((loc) => {
               const slug = loc.properties?.slug as Slug | undefined;
-              const title = slug && STATES[slug] ? `${STATES[slug].name} State` : null;
+              const title = slug && STATES[slug] ? STATES[slug].name : null;
               const valid = Boolean(title);
               const isActive = slug ? activeSet.has(slug) : false;
               const isPipeline = slug ? !isActive && pipelineSet.has(slug) : false;
@@ -220,7 +220,7 @@ export default function NigeriaMap({
           className="pointer-events-none absolute z-50 rounded-md bg-white/80 px-2 py-1 text-xs shadow backdrop-blur-sm"
           style={{ left: coords.x, top: coords.y }}
         >
-          {`${STATES[hoveredSlug].name} State`}
+          {STATES[hoveredSlug].name}
         </div>
       )}
     </div>

--- a/pages/country/index.tsx
+++ b/pages/country/index.tsx
@@ -15,9 +15,13 @@ export default function CountryPage() {
     return pool.filter((slug) => STATES[slug].name.toLowerCase().includes(needle));
   }, [q, pool]);
 
-  const links = Object.fromEntries(filtered.map((slug) => [slug, `/states/${slug}`]));
   const active = ACTIVE;
   const pipeline = PIPELINE;
+
+  const getHref = (slug: string) =>
+    active.includes(slug) || pipeline.includes(slug)
+      ? `/projects/nigeria/states/${slug}`
+      : `/projects/nigeria/states/${slug}/facts`;
 
   return (
     <>
@@ -84,7 +88,7 @@ export default function CountryPage() {
                 <span className="inline-flex items-center gap-1"><span className="inline-block h-3 w-3 rounded bg-[#E5E7EB]" /> Other</span>
               </div>
             </div>
-            <NigeriaMap active={active} pipeline={pipeline} links={links} />
+            <NigeriaMap active={active} pipeline={pipeline} />
           </section>
 
           {/* Right: State list */}
@@ -93,7 +97,7 @@ export default function CountryPage() {
               {filtered.map((slug) => (
                 <Link
                   key={slug}
-                  href={`/states/${slug}`}
+                  href={getHref(slug)}
                   className="flex items-center justify-between rounded-xl border px-3 py-2 hover:bg-muted min-h-12"
                 >
                   <div className="text-sm">


### PR DESCRIPTION
## Summary
- compute state URLs and wrap each map path with an anchor
- use link href for SSR fallback while preserving SPA navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0afe640208331b39fcdfb170497a8