### PR TITLE
Add modal for state facts with CTA

### DIFF
--- a/components/StateCard.tsx
+++ b/components/StateCard.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
-import React from "react";
+import React, { useState } from "react";
+import StateFactsCard from "./StateFactsCard";
 
 interface StateCardProps {
   slug: string;
@@ -10,7 +10,6 @@ interface StateCardProps {
   tags?: string[];
   updatedAt?: string;
   ctaLabel?: string;
-  href?: string;
 }
 
 const StateCard: React.FC<StateCardProps> = ({
@@ -22,72 +21,76 @@ const StateCard: React.FC<StateCardProps> = ({
   tags,
   updatedAt,
   ctaLabel,
-  href,
 }) => {
   const safeTags = Array.isArray(tags) ? tags.filter(Boolean) : [];
-  const link = href ?? `/states/${slug}`;
+  const [open, setOpen] = useState(false);
+
   return (
-    <Link
-      href={link}
-      className="group block focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 rounded-2xl"
-    >
-      <article
-        data-state-slug={slug}
-        className="h-full rounded-2xl border border-gray-200 bg-white shadow-sm hover:shadow-md transition-shadow">
-        <div className="p-5 sm:p-6">
-          <header className="flex items-center gap-2">
-            <span
-              className={`h-2.5 w-2.5 rounded-full ${(() => {
-                const s = status?.toLowerCase();
-                if (s === "active") return "bg-green-500";
-                if (s) return "bg-amber-500";
-                return "bg-slate-400";
-              })()}`}
-              aria-hidden
-            />
-            <h3 className="text-base sm:text-lg font-semibold tracking-tight group-hover:text-gray-900">
-              {title}
-            </h3>
-          </header>
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="group block w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 rounded-2xl"
+      >
+        <article
+          data-state-slug={slug}
+          className="h-full rounded-2xl border border-gray-200 bg-white shadow-sm hover:shadow-md transition-shadow"
+        >
+          <div className="p-5 sm:p-6">
+            <header className="flex items-center gap-2">
+              <span
+                className={`h-2.5 w-2.5 rounded-full ${(() => {
+                  const s = status?.toLowerCase();
+                  if (s === "active") return "bg-green-500";
+                  if (s) return "bg-amber-500";
+                  return "bg-slate-400";
+                })()}`}
+                aria-hidden
+              />
+              <h3 className="text-base sm:text-lg font-semibold tracking-tight group-hover:text-gray-900">
+                {title}
+              </h3>
+            </header>
 
-          {epithet && <p className="mt-1 text-sm text-gray-500">{epithet}</p>}
+            {epithet && <p className="mt-1 text-sm text-gray-500">{epithet}</p>}
 
-          {summary && (
-            <p className="mt-3 text-sm sm:text-[15px] leading-relaxed text-gray-700 line-clamp-3">
-              {summary}
-            </p>
-          )}
+            {summary && (
+              <p className="mt-3 text-sm sm:text-[15px] leading-relaxed text-gray-700 line-clamp-3">
+                {summary}
+              </p>
+            )}
 
-          {safeTags.length > 0 && (
-            <div className="mt-4 flex flex-wrap gap-2">
-              {safeTags.slice(0, 4).map((t) => (
-                <span
-                  key={t}
-                  className="inline-flex items-center px-2.5 py-1 rounded-full border border-gray-200 text-xs text-gray-700 bg-gray-50"
-                >
-                  {t}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {(updatedAt || ctaLabel) && (
-          <div className="hidden sm:flex items-center justify-between px-5 sm:px-6 py-3 border-t border-gray-100 bg-gray-50">
-            <span className="text-xs text-gray-500">
-              {updatedAt ? `Updated ${updatedAt}` : "\u00A0"}
-            </span>
-            {ctaLabel && (
-              <span className="text-xs font-medium text-emerald-700 group-hover:underline">
-                {ctaLabel} →
-              </span>
+            {safeTags.length > 0 && (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {safeTags.slice(0, 4).map((t) => (
+                  <span
+                    key={t}
+                    className="inline-flex items-center px-2.5 py-1 rounded-full border border-gray-200 text-xs text-gray-700 bg-gray-50"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
             )}
           </div>
-        )}
-      </article>
-    </Link>
+
+          {(updatedAt || ctaLabel) && (
+            <div className="hidden sm:flex items-center justify-between px-5 sm:px-6 py-3 border-t border-gray-100 bg-gray-50">
+              <span className="text-xs text-gray-500">
+                {updatedAt ? `Updated ${updatedAt}` : "\u00A0"}
+              </span>
+              {ctaLabel && (
+                <span className="text-xs font-medium text-emerald-700 group-hover:underline">
+                  {ctaLabel} →
+                </span>
+              )}
+            </div>
+          )}
+        </article>
+      </button>
+      {open && <StateFactsCard slug={slug} onClose={() => setOpen(false)} />}
+    </>
   );
 };
 
 export default StateCard;
-

--- a/components/StateFactsCard.tsx
+++ b/components/StateFactsCard.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef } from "react";
+import stateFacts from "@/data/stateFacts.json";
+import { X } from "lucide-react";
+
+interface Props {
+  slug: string;
+  onClose: () => void;
+}
+
+export default function StateFactsCard({ slug, onClose }: Props) {
+  const info = (stateFacts as Record<string, any>)[slug];
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const selectors =
+      'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    const focusables = Array.from(
+      node.querySelectorAll<HTMLElement>(selectors)
+    );
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    first?.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === "Tab" && focusables.length > 0) {
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  if (!info) return null;
+  const { facts = [], cta } = info;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        className="relative z-10 w-full max-w-md rounded-2xl bg-white p-6 shadow-lg"
+      >
+        <button
+          aria-label="Close"
+          onClick={onClose}
+          className="absolute right-3 top-3 rounded-md p-1 text-gray-500 hover:text-gray-700"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        <div className="space-y-4">
+          {facts.length > 0 && (
+            <ul className="list-disc pl-5 text-sm leading-relaxed space-y-2">
+              {facts.map((fact: string) => (
+                <li key={fact}>{fact}</li>
+              ))}
+            </ul>
+          )}
+          {cta && (
+            <div className="flex flex-col sm:flex-row gap-3 sm:justify-end">
+              <a
+                href={cta.primaryHref}
+                className="inline-flex items-center justify-center rounded-xl bg-black px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+              >
+                {cta.primaryLabel}
+              </a>
+              <a
+                href={cta.secondaryHref}
+                className="inline-flex items-center justify-center rounded-xl border px-4 py-2 text-sm font-medium hover:bg-gray-50"
+              >
+                {cta.secondaryLabel}
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/data/stateFacts.json
+++ b/data/stateFacts.json
@@ -1,0 +1,409 @@
+{
+  "abia": {
+    "facts": [
+      "Did you know that Abia's oil and gas reserves contribute significantly to Nigeria's carbon emissions, but its limestone deposits could support carbon capture technologies?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "adamawa": {
+    "facts": [
+      "Did you know that Adamawa's vast savannas act as natural carbon sinks, absorbing CO2 through grasslands that support over 1.5 million people in agriculture?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "akwa-ibom": {
+    "facts": [
+      "Did you know that Akwa Ibom's coastal mangroves store massive amounts of blue carbon, helping mitigate climate change while protecting against sea-level rise?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "anambra": {
+    "facts": [
+      "Did you know that Anambra's dense population of over 6 million faces increasing flood risks due to climate change, exacerbated by its riverine landscapes?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "bauchi": {
+    "facts": [
+      "Did you know that Bauchi's semi-arid climate makes it vulnerable to desertification, threatening the livelihoods of its 7 million residents reliant on farming?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "bayelsa": {
+    "facts": [
+      "Did you know that Bayelsa's oil fields are a hotspot for methane leaks, but its wetlands could be restored for carbon credits to combat environmental degradation?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "benue": {
+    "facts": [
+      "Did you know that Benue, known as Nigeria's 'Food Basket,' has rich farmlands that sequester carbon, feeding over 5 million people amid rising drought threats?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "borno": {
+    "facts": [
+      "Did you know that Borno's shrinking Lake Chad due to climate change has displaced millions, highlighting the human cost of desertification in the Sahel region?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "cross-river": {
+    "facts": [
+      "Did you know that Cross River hosts one of Nigeria's largest rainforests, a biodiversity hotspot that stores gigatons of carbon but faces deforestation pressures?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "delta": {
+    "facts": [
+      "Did you know that Delta's Niger Delta mangroves absorb CO2 equivalent to thousands of cars annually, yet oil spills have polluted ecosystems affecting 8 million locals?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "ebonyi": {
+    "facts": [
+      "Did you know that Ebonyi's lead mining contributes to environmental pollution, but its salt lakes could inspire sustainable practices in a warming climate?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "edo": {
+    "facts": [
+      "Did you know that Edo's tropical rainforests serve as vital carbon sinks, supporting biodiversity and the cultural heritage of its diverse ethnic groups?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "ekiti": {
+    "facts": [
+      "Did you know that Ekiti's hilly terrain and granite resources make it prone to erosion from heavy rains, impacting the farming communities of its 3 million people?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "enugu": {
+    "facts": [
+      "Did you know that Enugu's coal deposits have historically driven carbon emissions, but shifting to renewables could reduce its climate footprint significantly?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "gombe": {
+    "facts": [
+      "Did you know that Gombe's gemstone mining areas face land degradation, yet its savanna ecosystems help sequester carbon for its growing population?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "imo": {
+    "facts": [
+      "Did you know that Imo's oil and gas production adds to national emissions, but its palm oil plantations could be optimized for sustainable carbon-neutral biofuels?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "jigawa": {
+    "facts": [
+      "Did you know that Jigawa's arid climate leads to frequent droughts, affecting over 6 million people who depend on groundwater for survival?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "kaduna": {
+    "facts": [
+      "Did you know that Kaduna's diverse minerals like gold support livelihoods, but mining runoff worsens water scarcity in this climate-vulnerable northern state?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "kano": {
+    "facts": [
+      "Did you know that Kano, Nigeria's second-most populous state with over 15 million residents, faces urban heat islands amplified by climate change?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "katsina": {
+    "facts": [
+      "Did you know that Katsina's salt resources are threatened by desert encroachment, impacting traditional farming practices of its 8 million inhabitants?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "kebbi": {
+    "facts": [
+      "Did you know that Kebbi's gold mining boom could fund reforestation efforts to combat the state's high vulnerability to Sahelian droughts?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "kogi": {
+    "facts": [
+      "Did you know that Kogi's iron ore and coal resources contribute to industrial emissions, but its confluence of rivers makes it a key site for flood-related climate risks?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "kwara": {
+    "facts": [
+      "Did you know that Kwara's marble and gold deposits drive economic growth, yet increasing temperatures threaten the agricultural base for its 3 million people?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "lagos": {
+    "facts": [
+      "Did you know that Lagos, Africa's most populous city with over 20 million people, emits high urban carbon but leads in renewable energy initiatives like solar?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "nasarawa": {
+    "facts": [
+      "Did you know that Nasarawa's gemstones and barite are mined amid savanna landscapes that act as carbon buffers against central Nigeria's erratic rainfall?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "niger": {
+    "facts": [
+      "Did you know that Niger State, the largest by land area, has vast gold reserves but battles desertification that displaces nomadic herding communities?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "ogun": {
+    "facts": [
+      "Did you know that Ogun's phosphate and limestone support cement production with high CO2 output, yet its proximity to Lagos amplifies urban climate pressures?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "ondo": {
+    "facts": [
+      "Did you know that Ondo's bitumen reserves could be tapped for low-carbon roads, while its cocoa farms sequester CO2 for millions in the agricultural sector?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "osun": {
+    "facts": [
+      "Did you know that Osun's gold mining sites face environmental degradation from climate-driven erosion, affecting sacred forests tied to Yoruba culture?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "oyo": {
+    "facts": [
+      "Did you know that Oyo's kaolin and marble resources fuel industry, but its savanna climate exposes over 9 million people to heatwaves and water shortages?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "plateau": {
+    "facts": [
+      "Did you know that Plateau's highland climate provides a cool refuge in warming Nigeria, with tin mining lands potentially rehabilitated for carbon storage?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "rivers": {
+    "facts": [
+      "Did you know that Rivers State's oil industry is a major global carbon source, but its mangroves could offset emissions through blue carbon projects?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "sokoto": {
+    "facts": [
+      "Did you know that Sokoto's phosphate and gold support farming, yet extreme heat from climate change challenges the resilience of its 5 million residents?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "taraba": {
+    "facts": [
+      "Did you know that Taraba's gemstones are found in biodiverse mountains that serve as carbon sinks, protecting against floods for its ethnic diverse population?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "yobe": {
+    "facts": [
+      "Did you know that Yobe's gypsum resources are in a Sahel zone hit hard by drought, leading to food insecurity for over 3 million amid climate migration?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "zamfara": {
+    "facts": [
+      "Did you know that Zamfara's gold rush has caused lead poisoning crises, but community-led reforestation could build carbon resilience in this arid state?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  },
+  "fct-abuja": {
+    "facts": [
+      "Did you know that Abuja's marble and gold resources surround a planned city of 3 million, where urban greening efforts aim to reduce its carbon footprint?"
+    ],
+    "cta": {
+      "primaryLabel": "Book an expert",
+      "primaryHref": "/contact",
+      "secondaryLabel": "Register your interest",
+      "secondaryHref": "/contact?intent=policy-maker"
+    }
+  }
+}

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -82,7 +82,7 @@ export default function ProjectsPage({ live, cards, debug }: Props) {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {cards.map((p) => (
-          <StateCard key={p.slug} {...p} href={`/projects/nigeria/states/${p.slug}`} />
+          <StateCard key={p.slug} {...p} />
         ))}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- wire `stateFacts.json` for per-state facts and calls to action
- show state facts modal from StateCard with focus trap and escape/overlay close

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0cf137d508331860c7e3b32559217