### PR TITLE
Add breadcrumb navigation component

### DIFF
--- a/components/Breadcrumb.tsx
+++ b/components/Breadcrumb.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Link from 'next/link';
+
+export interface BreadcrumbSegment {
+  href: string;
+  label: string;
+}
+
+interface BreadcrumbProps {
+  segments: BreadcrumbSegment[];
+}
+
+const Breadcrumb: React.FC<BreadcrumbProps> = ({ segments }) => {
+  return (
+    <nav aria-label="Breadcrumb" className="text-sm text-muted-foreground">
+      <ol className="flex flex-wrap items-center gap-1">
+        {segments.map((segment, index) => (
+          <li key={segment.href} className="flex items-center">
+            <Link href={segment.href} title={segment.label} className="hover:underline">
+              {segment.label}
+            </Link>
+            {index < segments.length - 1 && <span className="mx-2">&gt;</span>}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};
+
+export default Breadcrumb;

--- a/pages/country/index.tsx
+++ b/pages/country/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import NigeriaMap from "@/components/NigeriaMap";
+import Breadcrumb from "@/components/Breadcrumb";
 import { STATES, ACTIVE, PIPELINE, META, SLUGS } from "@/data/country";
 
 export default function CountryPage() {
@@ -46,6 +47,13 @@ export default function CountryPage() {
         />
       </Head>
       <main className="max-w-7xl mx-auto p-6 space-y-6">
+        <Breadcrumb
+          segments={[
+            { href: "/", label: "Home" },
+            { href: "/countries", label: "Countries" },
+            { href: "/country", label: "Nigeria" },
+          ]}
+        />
         <header className="space-y-2">
           <h1 className="text-3xl font-semibold tracking-tight">Nigeria Overview</h1>
           <p className="text-muted-foreground">States we’re actively engaging.</p>

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { GetServerSideProps } from "next";
 import StateCard from "@/components/StateCard";
 import Leaderboard from "@/components/Leaderboard";
+import Breadcrumb from "@/components/Breadcrumb";
 import { getLeaderboard, type LiveItem } from "@/lib/leaderboard";
 import { enrich, sortByTotal, type ScoredItem } from "@/lib/scoring";
 import { projects as localProjects } from "@/data/projects";
@@ -67,6 +68,14 @@ export const getServerSideProps: GetServerSideProps<Props> = async () => {
 export default function ProjectsPage({ live, cards, debug }: Props) {
   return (
     <main className="max-w-6xl mx-auto p-6 space-y-6">
+      <Breadcrumb
+        segments={[
+          { href: "/", label: "Home" },
+          { href: "/countries", label: "Countries" },
+          { href: "/country", label: "Nigeria" },
+          { href: "/projects", label: "Projects" },
+        ]}
+      />
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight">Projects</h1>
         <p className="text-muted-foreground">Active and upcoming state engagements.</p>

--- a/pages/projects/nigeria/states/[slug]/facts.tsx
+++ b/pages/projects/nigeria/states/[slug]/facts.tsx
@@ -1,43 +1,43 @@
 import { useRouter } from "next/router";
-import Link from "next/link";
 import CTA from "@/components/CTA";
+import Breadcrumb from "@/components/Breadcrumb";
 import { getStateFacts } from "@/data/stateFacts";
+import { toTitle } from "@/data/country";
 
 export default function NigeriaStateFactsPage() {
   const { slug } = useRouter().query;
-  const name = typeof slug === "string" ? slug : "";
-  const facts = getStateFacts(name);
+  const slugStr = typeof slug === "string" ? slug : "";
+  const name = slugStr ? toTitle(slugStr) : "";
+  const facts = getStateFacts(slugStr);
 
   return (
-    <>
-      <header className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-6">
-        <Link
-          href="/projects"
-          className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
-        >
-          <span className="mr-2">←</span> Back to Projects
-        </Link>
-      </header>
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 md:pt-20">
-        <div className="overflow-hidden rounded-3xl border bg-gradient-to-br from-white to-gray-50 shadow-md">
-          <div className="border-b bg-white/60 p-8 sm:p-10">
-            <h1 className="text-3xl md:text-4xl font-semibold tracking-tight capitalize">{name} Facts</h1>
-          </div>
-          <div className="space-y-8 p-8 sm:p-10">
-            {facts.length > 0 ? (
-              <ul className="list-disc pl-5 space-y-4 text-base md:text-lg leading-relaxed">
-                {facts.map((fact) => (
-                  <li key={fact}>{fact}</li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-base md:text-lg text-muted-foreground">No facts available.</p>
-            )}
-            <CTA />
-          </div>
+    <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 md:pt-20 space-y-6">
+      <Breadcrumb
+        segments={[
+          { href: "/", label: "Home" },
+          { href: "/countries", label: "Countries" },
+          { href: "/country", label: "Nigeria" },
+          { href: "/projects", label: "Projects" },
+          { href: `/projects/nigeria/states/${slugStr}/facts`, label: `${name} Facts` },
+        ]}
+      />
+      <div className="overflow-hidden rounded-3xl border bg-gradient-to-br from-white to-gray-50 shadow-md">
+        <div className="border-b bg-white/60 p-8 sm:p-10">
+          <h1 className="text-3xl md:text-4xl font-semibold tracking-tight capitalize">{name} Facts</h1>
         </div>
-      </main>
-    </>
+        <div className="space-y-8 p-8 sm:p-10">
+          {facts.length > 0 ? (
+            <ul className="list-disc pl-5 space-y-4 text-base md:text-lg leading-relaxed">
+              {facts.map((fact) => (
+                <li key={fact}>{fact}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-base md:text-lg text-muted-foreground">No facts available.</p>
+          )}
+          <CTA />
+        </div>
+      </div>
+    </main>
   );
 }
-

--- a/pages/projects/nigeria/states/[slug]/index.tsx
+++ b/pages/projects/nigeria/states/[slug]/index.tsx
@@ -1,31 +1,31 @@
 import { useRouter } from "next/router";
-import Link from "next/link";
 import StateDetailsCarousel from "@/components/StateDetailsCarousel";
+import Breadcrumb from "@/components/Breadcrumb";
+import { toTitle } from "@/data/country";
 
 const ORDER = ["niger", "kwara", "plateau"];
 
 export default function NigeriaStatePage() {
-  const router = useRouter();
-  const { slug } = router.query;
-  const startIndex = typeof slug === "string" ? ORDER.indexOf(slug) : 0;
+  const { slug } = useRouter().query;
+  const slugStr = typeof slug === "string" ? slug : "";
+  const startIndex = slugStr ? ORDER.indexOf(slugStr) : 0;
+  const name = slugStr ? toTitle(slugStr) : "";
 
   return (
-    <>
-      <header className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-6">
-        <Link
-          href="/projects"
-          className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
-        >
-          <span className="mr-2">←</span> Back to Projects
-        </Link>
-      </header>
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 md:pt-20">
-        <StateDetailsCarousel
-          states={ORDER}
-          startIndex={startIndex >= 0 ? startIndex : 0}
-        />
-      </main>
-    </>
+    <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 md:pt-20 space-y-6">
+      <Breadcrumb
+        segments={[
+          { href: "/", label: "Home" },
+          { href: "/countries", label: "Countries" },
+          { href: "/country", label: "Nigeria" },
+          { href: "/projects", label: "Projects" },
+          { href: `/projects/nigeria/states/${slugStr}`, label: name },
+        ]}
+      />
+      <StateDetailsCarousel
+        states={ORDER}
+        startIndex={startIndex >= 0 ? startIndex : 0}
+      />
+    </main>
   );
 }
-

--- a/pages/states/[slug].tsx
+++ b/pages/states/[slug].tsx
@@ -1,31 +1,31 @@
 import { useRouter } from "next/router";
-import Link from "next/link";
 import StateDetailsCarousel from "@/components/StateDetailsCarousel";
+import Breadcrumb from "@/components/Breadcrumb";
+import { toTitle } from "@/data/country";
 
 const ORDER = ["niger", "kwara", "plateau"];
 
 export default function StatePage() {
-  const router = useRouter();
-  const { slug } = router.query;
-  const startIndex = typeof slug === "string" ? ORDER.indexOf(slug) : 0;
+  const { slug } = useRouter().query;
+  const slugStr = typeof slug === "string" ? slug : "";
+  const startIndex = slugStr ? ORDER.indexOf(slugStr) : 0;
+  const name = slugStr ? toTitle(slugStr) : "";
 
   return (
-    <>
-      <header className="max-w-6xl mx-auto px-4 sm:px-6 pt-4 md:pt-6">
-        <Link
-          href="/projects"
-          className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
-        >
-          <span className="mr-2">←</span> Back to Projects
-        </Link>
-      </header>
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 md:pt-20">
-        <StateDetailsCarousel
-          states={ORDER}
-          startIndex={startIndex >= 0 ? startIndex : 0}
-        />
-      </main>
-    </>
+    <main className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 md:pt-20 space-y-6">
+      <Breadcrumb
+        segments={[
+          { href: "/", label: "Home" },
+          { href: "/countries", label: "Countries" },
+          { href: "/country", label: "Nigeria" },
+          { href: "/projects", label: "Projects" },
+          { href: `/states/${slugStr}`, label: name },
+        ]}
+      />
+      <StateDetailsCarousel
+        states={ORDER}
+        startIndex={startIndex >= 0 ? startIndex : 0}
+      />
+    </main>
   );
 }
-


### PR DESCRIPTION
## Summary
- Implement reusable Breadcrumb component
- Display hierarchical links on country, project, and state pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a15d97088083319f3369509724ab65