### PR TITLE
Add flattened breadcrumb for Nigeria projects

### DIFF
--- a/components/Breadcrumb.tsx
+++ b/components/Breadcrumb.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+interface Item {
+  label: string;
+  href?: string;
+}
+
+export default function Breadcrumb({ items }: { items: Item[] }) {
+  return (
+    <nav aria-label="Breadcrumb" className="text-sm text-muted-foreground">
+      <ol className="flex flex-wrap items-center gap-1">
+        {items.map((item, idx) => (
+          <li key={item.label} className="flex items-center gap-1">
+            {idx > 0 && <span>&gt;</span>}
+            {item.href ? (
+              <Link href={item.href} className="hover:underline">
+                {item.label}
+              </Link>
+            ) : (
+              <span aria-current="page">{item.label}</span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { GetServerSideProps } from "next";
 import StateCard from "@/components/StateCard";
 import Leaderboard from "@/components/Leaderboard";
+import Breadcrumb from "@/components/Breadcrumb";
 import { getLeaderboard, type LiveItem } from "@/lib/leaderboard";
 import { enrich, sortByTotal, type ScoredItem } from "@/lib/scoring";
 import { projects as localProjects } from "@/data/projects";
@@ -67,6 +68,13 @@ export const getServerSideProps: GetServerSideProps<Props> = async () => {
 export default function ProjectsPage({ live, cards, debug }: Props) {
   return (
     <main className="max-w-6xl mx-auto p-6 space-y-6">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Nigeria", href: "/country" },
+          { label: "Projects" },
+        ]}
+      />
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight">Projects</h1>
         <p className="text-muted-foreground">Active and upcoming state engagements.</p>

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -2,7 +2,7 @@
 export const navigationLinks = [
   { href: '/technology', label: 'Technology' },
   { href: '/projects', label: 'Projects' },
-  { href: '/country', label: 'Countries' },
+  { href: '/country', label: 'Nigeria' },
   { href: '/about-us', label: 'About Us' },
   { href: '/contact', label: 'Contact' }
 ];


### PR DESCRIPTION
## Summary
- add reusable Breadcrumb component
- show `Home > Nigeria > Projects` on projects page
- rename navigation link to Nigeria to match flattened breadcrumb

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a16a6a57f0833180d2e47c75229569