### PR TITLE
Reset scroll position on navigation

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,8 +3,23 @@ import Head from 'next/head'; // Import Head
 import '../styles/globals.css'; // Import global styles
 import type { AppProps } from 'next/app';
 import Layout from '../components/Layout'; // Import your Layout component
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      window.scrollTo(0, 0);
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## Summary
- ensure each page loads at the top after navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a19ae37b548331975ff735088260aa