### PR TITLE
feat: scroll to top on navigation

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,8 +3,24 @@ import Head from 'next/head'; // Import Head
 import '../styles/globals.css'; // Import global styles
 import type { AppProps } from 'next/app';
 import Layout from '../components/Layout'; // Import your Layout component
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      window.scrollTo(0, 0);
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <>
       <Head>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,11 +15,13 @@ function MyApp({ Component, pageProps }: AppProps) {
     };
 
     router.events.on('routeChangeComplete', handleRouteChange);
+    // Ensure the first render also starts at the top on all devices
+    handleRouteChange();
 
     return () => {
       router.events.off('routeChangeComplete', handleRouteChange);
     };
-  }, [router.events]);
+  }, [router]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Scroll to top after each route change using Next.js router events.
- Clean up event listener on unmount to avoid memory leaks.

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a19d22e6cc8331bd71fe62a39396cc