### PR TITLE
Reset scroll on route changes

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,8 +3,30 @@ import Head from 'next/head'; // Import Head
 import '../styles/globals.css'; // Import global styles
 import type { AppProps } from 'next/app';
 import Layout from '../components/Layout'; // Import your Layout component
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if ('scrollRestoration' in window.history) {
+      window.history.scrollRestoration = 'manual';
+    }
+
+    const handleRouteChange = () => {
+      window.scrollTo(0, 0);
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+    router.events.on('hashChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+      router.events.off('hashChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## Summary
- reset scroll position to top on route changes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1ac7820708331add3bdcd0631a3b8