### PR TITLE
Fix hero gap and add hero content animation

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -3,9 +3,11 @@ import Link from 'next/link';
 
 const HeroSection: React.FC = () => {
   const [isClient, setIsClient] = useState(false);
+  const [contentVisible, setContentVisible] = useState(false);
 
   useEffect(() => {
     setIsClient(true);
+    setContentVisible(true);
   }, []);
 
   return (
@@ -23,18 +25,24 @@ const HeroSection: React.FC = () => {
         <div className="absolute inset-0 w-full h-full bg-black" />
       )}
       <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-center px-4">
-        <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl">
-          The carbon stack for countries
-        </h1>
-        <p className="mt-6 text-white text-lg md:text-xl font-medium tracking-wide">
-          We measure, we report, we verify
-        </p>
-        <Link
-          href="/contact"
-          className="mt-10 inline-block rounded-md bg-white/10 px-6 py-3 text-base font-semibold text-white backdrop-blur-sm border border-white/20 shadow-lg transition hover:bg-white/20"
+        <div
+          className={`transform transition-all duration-700 ease-out ${
+            contentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+          }`}
         >
-          Book an expert
-        </Link>
+          <h1 className="text-white text-5xl md:text-6xl font-semibold tracking-tight drop-shadow-xl">
+            The carbon stack for countries
+          </h1>
+          <p className="mt-6 text-white text-lg md:text-xl font-medium tracking-wide">
+            We measure, we report, we verify
+          </p>
+          <Link
+            href="/contact"
+            className="mt-10 inline-block rounded-md bg-white/10 px-6 py-3 text-base font-semibold text-white backdrop-blur-sm border border-white/20 shadow-lg transition hover:bg-white/20"
+          >
+            Book an expert
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,5 +1,6 @@
 // components/Layout.tsx
 import React, { ReactNode } from 'react';
+import { useRouter } from 'next/router';
 import NavBar from './NavBar';
 import Footer from './Footer';
 
@@ -8,12 +9,13 @@ interface LayoutProps {
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
+  const router = useRouter();
+  const isHome = router.pathname === '/';
+
   return (
     <div className="flex flex-col min-h-screen">
       <NavBar />
-      <main className="flex-grow pt-16">
-        {children}
-      </main>
+      <main className={`flex-grow ${isHome ? '' : 'pt-16'}`}>{children}</main>
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- remove default main padding on home page so hero video meets navbar
- fade in hero heading, text, and button with subtle upward motion

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1c1e5a9e4833184ab50232764f60a