### PR TITLE
Refine country map colors and update FCT naming

### DIFF
--- a/components/NigeriaMap.tsx
+++ b/components/NigeriaMap.tsx
@@ -116,12 +116,12 @@ export default function NigeriaMap({
                 ? "#16A34A"
                 : isPipeline
                 ? "#FBBF24"
-                : "#E5E7EB";
+                : "#FFFFFF";
               const hoverFill = isActive
                 ? "#22C55E"
                 : isPipeline
                 ? "#FCD34D"
-                : "#22C55E";
+                : "#E5E7EB";
               const entry = slug ? divisionMap.get(slug) : undefined;
               const href = entry
                 ? entry.inPipeline
@@ -187,7 +187,7 @@ export default function NigeriaMap({
                 className: `transition-colors ${entry ? "cursor-pointer" : "pointer-events-none"}`,
                 style: {
                   fill: baseFill,
-                  stroke: "#D1D5DB",
+                  stroke: "#4B5563",
                   strokeWidth: 1.5,
                   pointerEvents: entry ? undefined : "none",
                 },

--- a/components/NigeriaMap.tsx
+++ b/components/NigeriaMap.tsx
@@ -187,7 +187,7 @@ export default function NigeriaMap({
                 className: `transition-colors ${entry ? "cursor-pointer" : "pointer-events-none"}`,
                 style: {
                   fill: baseFill,
-                  stroke: "#4B5563",
+                  stroke: "#6B7280",
                   strokeWidth: 1.5,
                   pointerEvents: entry ? undefined : "none",
                 },

--- a/data/country.ts
+++ b/data/country.ts
@@ -39,7 +39,7 @@ export const SLUGS = [
 ] as const;
 
 export const STATES = Object.fromEntries(
-  SLUGS.map((s) => [s, { name: toTitle(s) }])
+  SLUGS.map((s) => [s, { name: s === "fct" ? "FCT" : toTitle(s) }])
 ) as Record<string, { name: string }>;
 
 export const ACTIVE = [] as string[];


### PR DESCRIPTION
## Summary
- Show inactive states in white with dark grey borders and light grey hover
- Keep active states green, pipeline states orange
- Rename Fct to capitalized FCT in state metadata

## Testing
- ⚠️ `npm test` (script missing)
- ✅ `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a20feb84f88331a7da9ecb1eed50b5