### PR TITLE
Lighten map appearance and rename FCT

### DIFF
--- a/components/NigeriaMap.tsx
+++ b/components/NigeriaMap.tsx
@@ -116,12 +116,12 @@ export default function NigeriaMap({
                 ? "#16A34A"
                 : isPipeline
                 ? "#FBBF24"
-                : "#E5E7EB";
+                : "#F3F4F6";
               const hoverFill = isActive
                 ? "#22C55E"
                 : isPipeline
                 ? "#FCD34D"
-                : "#22C55E";
+                : "#E5E7EB";
               const entry = slug ? divisionMap.get(slug) : undefined;
               const href = entry
                 ? entry.inPipeline

--- a/components/NigeriaMap.tsx
+++ b/components/NigeriaMap.tsx
@@ -115,12 +115,12 @@ export default function NigeriaMap({
               const baseFill = isActive
                 ? "#16A34A"
                 : isPipeline
-                ? "#FBBF24"
+                ? "#FCD34D"
                 : "#F3F4F6";
               const hoverFill = isActive
                 ? "#22C55E"
                 : isPipeline
-                ? "#FCD34D"
+                ? "#FBBF24"
                 : "#E5E7EB";
               const entry = slug ? divisionMap.get(slug) : undefined;
               const href = entry

--- a/data/country.ts
+++ b/data/country.ts
@@ -53,5 +53,7 @@ export const META: Record<string, { tag?: string }> = {
 };
 
 export function toTitle(slug: string) {
-  return slug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  const normal = slug.replace(/-/g, " ");
+  if (normal === "fct") return "FCT";
+  return normal.replace(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/pages/country/index.tsx
+++ b/pages/country/index.tsx
@@ -93,7 +93,7 @@ export default function CountryPage() {
               {/* Legend */}
               <div className="flex items-center gap-3 text-xs">
                 <span className="inline-flex items-center gap-1"><span className="inline-block h-3 w-3 rounded bg-[#16A34A]" /> Active</span>
-                <span className="inline-flex items-center gap-1"><span className="inline-block h-3 w-3 rounded bg-[#FBBF24]" /> Pipeline</span>
+                  <span className="inline-flex items-center gap-1"><span className="inline-block h-3 w-3 rounded bg-[#FCD34D]" /> Pipeline</span>
                 <span className="inline-flex items-center gap-1"><span className="inline-block h-3 w-3 rounded bg-[#E5E7EB]" /> Other</span>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Lighten default map fill and use gray hover to match the requested styling
- Normalize FCT naming to display fully capitalized

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2145e09148331a67e55a54a6caac9