### PR TITLE
Set document language attribute

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,7 +4,8 @@ import Document, { Html, Head, Main, NextScript } from 'next/document';
 class MyDocument extends Document {
   render() {
     return (
-      <Html>
+      <Html lang={this.props.__NEXT_DATA__.locale ?? 'en'}>
+        {/* Set the document language; default to English but allow dynamic locale if provided */}
         <Head>
           {/* Other tags like your stylesheet links can also go here */}
         </Head>


### PR DESCRIPTION
## Summary
- default HTML document to English and allow dynamic locale selection

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a44162ca248331b5adbdfa825827c5