### PR TITLE
fix: replace legacy navbar with preview header on homepage

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -2,6 +2,7 @@
 import React, { ReactNode } from 'react';
 import { useRouter } from 'next/router';
 import NavBar from './NavBar';
+import PreviewHeader from './preview/PreviewHeader';
 import Footer from './Footer';
 
 interface LayoutProps {
@@ -14,7 +15,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
   return (
     <div className="flex flex-col min-h-screen">
-      <NavBar />
+      {isHome ? <PreviewHeader /> : <NavBar />}
       <main className={`flex-grow ${isHome ? '' : 'pt-16'}`}>{children}</main>
       <Footer />
     </div>

--- a/components/preview/PreviewHeader.tsx
+++ b/components/preview/PreviewHeader.tsx
@@ -9,7 +9,8 @@ const BASE = '/preview/verification-readiness';
 const PreviewHeader: React.FC = () => {
   const [open, setOpen] = useState(false);
   const router = useRouter();
-  const isHomePage = router.pathname === '/preview/verification-readiness';
+  const isHomePage = router.pathname === '/' || router.pathname === '/preview/verification-readiness';
+  const brandHref = router.pathname === '/' ? '/' : BASE;
 
   useEffect(() => {
     const handleResize = () => {
@@ -55,7 +56,7 @@ const PreviewHeader: React.FC = () => {
     <header className="sticky top-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur-sm">
       <nav className="mx-auto max-w-6xl flex items-center justify-between px-4 py-2.5 md:py-3.5">
         <Link
-          href={BASE}
+          href={brandHref}
           className="text-base font-bold tracking-wide text-forest-900 shrink-0"
         >
           ARTICLE6


### PR DESCRIPTION
## Problem

The verification-readiness homepage at `/` renders the legacy NavBar with links to Technology, Projects, Countries, About Us, and Contact. The landing page should use the minimal preview header with the Article6 brand mark and Upload PDD CTA instead.

## Fix

- `Layout.tsx`: Renders `PreviewHeader` on `/` instead of `NavBar`
- `PreviewHeader.tsx`: Updated `isHomePage` and `brandHref` to handle both `/` and `/preview/verification-readiness`
- Legacy `NavBar` preserved for all other non-preview pages

## Validation

| Check | Result |
|---|---|
| `/` returns 200 | ✅ |
| Legacy nav links absent from `/` | ✅ |
| Upload PDD CTA visible on `/` | ✅ |
| Non-homepage pages still have legacy NavBar | ✅ |
| Upload form present on `/` | ✅ |
| `npx tsc --noEmit` | ✅ |
| `npx next lint` | ✅ |
| `git diff --check` | ✅ |

## Files changed

- `components/Layout.tsx`
- `components/preview/PreviewHeader.tsx`

Only the homepage layout changed. Body content, upload flow, API routes, R2 config, and email flow are untouched.