### PR TITLE
fix: remove redundant intro block from How It Works page

### DIFF
--- a/pages/preview/verification-readiness/how-it-works.tsx
+++ b/pages/preview/verification-readiness/how-it-works.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import PreviewHero from '../../../components/preview/PreviewHero';
 import SectionHeading from '../../../components/preview/SectionHeading';
 import ProcessStep from '../../../components/preview/ProcessStep';
 import Link from 'next/link';
@@ -17,13 +16,8 @@ export default function HowItWorksPage() {
         />
       </Head>
 
-      <PreviewHero
-        headline="How the assessment works"
-        body="A clear process from project documents to a reviewed readiness report."
-      />
-
       {/* Process */}
-      <section className="mx-auto max-w-6xl px-4 py-16 md:py-24">
+      <section className="mx-auto max-w-6xl px-4 py-16 md:py-20">
         <div className="max-w-2xl mx-auto space-y-8">
           <ProcessStep step={1} title="Share your documents">
             Provide the current PDD and relevant supporting materials through an agreed secure


### PR DESCRIPTION
## Problem

`/preview/verification-readiness/how-it-works` shows a large empty vertical gap between the header and the process steps. The `PreviewHero` component renders the intro block "How the assessment works" / "A clear process from project documents..." with `py-12 md:py-20 lg:py-24` padding.

## Fix

- Removed the `PreviewHero` import and component entirely from the page
- Process steps section now begins near the top with `py-16 md:py-20`
- All 5 process steps, downstream sections (Human review, What the assessment does not replace), and CTA preserved

## Removed layout rule

`PreviewHero` with `py-12 md:py-20 lg:py-24` plus the internal grid — this was the only source of the large blank gap.

## Validation

| Check | Result |
|---|---|
| Route returns 200 | ✅ |
| Intro heading "How the assessment works" absent | ✅ |
| PreviewHero body class `mt-4 max-w-xl` absent | ✅ |
| All 5 process steps present | ✅ |
| Responsive layout intact | ✅ |
| `npx tsc --noEmit` | ✅ |
| `npx next lint` | ✅ |
| `git diff --check` | ✅ |
| Other pages unaffected | ✅ (page-level change only)