### PR TITLE
feat: add green logo and favicon matching app.article6.org

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -5,7 +5,7 @@ const Footer: React.FC = () => {
   return (
     <footer className="bg-gray-200 text-center p-4 text-sm text-gray-700">
       <p>
-        &copy; {new Date().getFullYear()} Article<span className="text-green-600">6</span> All rights
+        &copy; {new Date().getFullYear()} Article<span className="text-forest-700">6</span> All rights
         reserved.
       </p>
       {/* You can add more footer content here such as social links */}

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -16,7 +16,7 @@ export default function Logo({
   const content = (
     <>
       <span
-        className={`flex h-8 w-8 items-center justify-center rounded-lg bg-forest-700 text-[11px] font-extrabold tracking-tight text-white shrink-0 ${markClassName}`}
+        className={`flex h-8 w-8 items-center justify-center rounded-lg bg-forest-800 text-[11px] font-extrabold tracking-tight text-white shrink-0 ${markClassName}`}
       >
         A6
       </span>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+
+interface LogoProps {
+  href?: string;
+  className?: string;
+  markClassName?: string;
+  textClassName?: string;
+}
+
+export default function Logo({
+  href = '/',
+  className = '',
+  markClassName = '',
+  textClassName = '',
+}: LogoProps) {
+  const content = (
+    <>
+      <span
+        className={`flex h-8 w-8 items-center justify-center rounded-lg bg-forest-700 text-[11px] font-extrabold tracking-tight text-white shrink-0 ${markClassName}`}
+      >
+        A6
+      </span>
+      <span className={`text-sm font-semibold text-forest-700 ${textClassName}`}>
+        Article6
+      </span>
+    </>
+  );
+
+  const linkClasses = `flex items-center gap-2.5 rounded-xl px-2 py-1 transition hover:bg-forest-50 ${className}`;
+
+  if (href) {
+    return (
+      <Link href={href} className={linkClasses}>
+        {content}
+      </Link>
+    );
+  }
+
+  return <span className={linkClasses}>{content}</span>;
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { navigationLinks } from '../utils/navigation';
+import Logo from './Logo';
 
 const NavBar: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -22,9 +23,7 @@ const NavBar: React.FC = () => {
   return (
     <header className="bg-white shadow-md fixed w-full z-50">
       <nav className="container mx-auto flex items-center justify-between p-4">
-        <Link href="/" className="flex items-center text-lg font-bold">
-          Article<span className="text-green-600">6</span>
-        </Link>
+        <Logo href="/" />
 
         <ul className="hidden md:flex gap-12">
           {navigationLinks.map(({ href, label }) => (

--- a/components/preview/PreviewFooter.tsx
+++ b/components/preview/PreviewFooter.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { previewNavigationLinks } from './navigation';
+import Logo from '../Logo';
 
 const BASE = '/preview/verification-readiness';
 
@@ -8,9 +9,7 @@ const PreviewFooter: React.FC = () => {
   return (
     <footer className="border-t border-gray-200 bg-white">
       <div className="mx-auto max-w-6xl px-4 py-10 md:py-12">
-        <Link href={BASE} className="text-base font-bold tracking-wide text-forest-900">
-          ARTICLE6
-        </Link>
+        <Logo href={BASE} />
         <p className="mt-2 text-sm text-gray-500">
           Evidence readiness assessments for carbon projects.
         </p>

--- a/components/preview/PreviewHeader.tsx
+++ b/components/preview/PreviewHeader.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { previewNavigationLinks, previewCtaLink } from './navigation';
+import Logo from '../Logo';
 
 const BASE = '/preview/verification-readiness';
 
@@ -55,12 +56,7 @@ const PreviewHeader: React.FC = () => {
   return (
     <header className="sticky top-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur-sm">
       <nav className="mx-auto max-w-6xl flex items-center justify-between px-4 py-2.5 md:py-3.5">
-        <Link
-          href={brandHref}
-          className="text-base font-bold tracking-wide text-forest-900 shrink-0"
-        >
-          ARTICLE6
-        </Link>
+        <Logo href={brandHref} />
 
         <ul className="hidden md:flex items-center gap-6">
           {previewNavigationLinks.map(({ href, label }) => {

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,7 +7,8 @@ class MyDocument extends Document {
       <Html lang={this.props.__NEXT_DATA__.locale ?? 'en'}>
         {/* Set the document language; default to English but allow dynamic locale if provided */}
         <Head>
-          {/* Other tags like your stylesheet links can also go here */}
+          <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+          <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="16x16" />
         </Head>
         <body>
           <Main />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -8,7 +8,6 @@ class MyDocument extends Document {
         {/* Set the document language; default to English but allow dynamic locale if provided */}
         <Head>
           <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-          <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="16x16" />
         </Head>
         <body>
           <Main />

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#145225"/>
+  <text x="256" y="368" text-anchor="middle" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-weight="800" font-size="310" fill="#ffffff" letter-spacing="-16">A6</text>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <rect width="512" height="512" rx="96" fill="#145225"/>
+  <rect width="512" height="512" rx="96" fill="#0d3d1a"/>
   <text x="256" y="368" text-anchor="middle" font-family="system-ui, -apple-system, Helvetica, Arial, sans-serif" font-weight="800" font-size="310" fill="#ffffff" letter-spacing="-16">A6</text>
 </svg>


### PR DESCRIPTION
## Problem

The site uses plain text branding ("ARTICLE6", "Article6", "Article**6**") with no logo mark or favicon.

## Fix

Added a reusable `Logo` component matching the app.article6.org design pattern but in green (forest-700) instead of black:

- **Mark**: "A6" in a green rounded square (`bg-forest-700`), white text
- **Wordmark**: "Article6" text next to it (`text-forest-700`)
- **Favicon**: Same mark as SVG favicon

## Files changed

| File | Change |
|------|--------|
| `components/Logo.tsx` | **NEW** — reusable A6 logo component |
| `public/favicon.svg` | **NEW** — green A6 favicon |
| `components/NavBar.tsx` | Use Logo instead of plain text |
| `components/Footer.tsx` | Update brand color to forest-700 |
| `components/preview/PreviewHeader.tsx` | Use Logo instead of plain text |
| `components/preview/PreviewFooter.tsx` | Use Logo instead of plain text |
| `pages/_document.tsx` | Add favicon SVG link |

## Validation

| Check | Result |
|---|---|
| Logo renders on `/` (PreviewHeader) | ✅ |
| Logo renders on `/contact` (NavBar) | ✅ |
| Logo renders on preview sub-pages | ✅ |
| `npx tsc --noEmit` | ✅ |
| `npx next lint` | ✅ |
| `git diff --check` | ✅ |