### PR TITLE
feat: support internal PDD submissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ RESEND_API_KEY=
 SUBMISSION_FROM_EMAIL=submissions@article6.org
 ADMIN_NOTIFICATION_EMAIL=contact@article6.org
 
+# Internal PDD upload protection (server-only; never use NEXT_PUBLIC_* names)
+# The /internal/submissions/new route uses HTTP Basic Auth and issues a short-lived HttpOnly session cookie.
+INTERNAL_UPLOAD_USERNAME=
+INTERNAL_UPLOAD_PASSWORD=
+
 # Google Sheets (existing, for leaderboard)
 GOOGLE_SHEETS_CLIENT_EMAIL=
 GOOGLE_SHEETS_PRIVATE_KEY=

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
+## Internal PDD submissions
+
+`/internal/submissions/new` is not linked from the public site. It is protected by server-side HTTP Basic Auth using `INTERNAL_UPLOAD_USERNAME` and `INTERNAL_UPLOAD_PASSWORD`. After successful authentication, middleware issues an eight-hour, HttpOnly, SameSite cookie; the upload APIs require that cookie for non-website submissions. These variables must remain server-only and must not use `NEXT_PUBLIC_*` names.
+
+The workflow keeps PDF bytes out of Next.js: the browser requests a short-lived presigned PUT URL, uploads directly to the configured private R2 bucket, and calls the confirmation API. Confirmation verifies the private object’s key, existence, size, and content type before sending the internal notification. The app does not return a permanent R2 object URL.
+
+The Basic Auth credentials are shared operator credentials, not individual user accounts. Rotate them through the deployment environment when needed. Preview and production storage are isolated only when their `R2_BUCKET_NAME` values are configured to different buckets; this repository does not define a separate preview bucket automatically, so verify the configured values before uploading sensitive documents to a preview.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/components/preview/PddUploadForm.tsx
+++ b/components/preview/PddUploadForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import { isPdfUpload, MAX_FILE_SIZE, type SubmissionSource } from '../../lib/submissions';
 
 const inputClasses =
   'w-full rounded-md border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-forest-500 focus:border-forest-500 transition';
@@ -12,9 +13,16 @@ interface FormFields {
   projectName: string;
   methodology: string;
   note: string;
+  externalContact: string;
+  submissionSource: Exclude<SubmissionSource, 'website'>;
 }
 
-const PddUploadForm: React.FC = () => {
+interface PddUploadFormProps {
+  mode?: 'public' | 'internal';
+}
+
+const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
+  const isInternal = mode === 'internal';
   const [phase, setPhase] = useState<UploadPhase>('idle');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [submissionId, setSubmissionId] = useState<string>('');
@@ -25,6 +33,8 @@ const PddUploadForm: React.FC = () => {
     projectName: '',
     methodology: '',
     note: '',
+    externalContact: '',
+    submissionSource: 'internal',
   });
   const [fileName, setFileName] = useState<string>('');
   const [file, setFile] = useState<File | null>(null);
@@ -48,16 +58,13 @@ const PddUploadForm: React.FC = () => {
   const validateForm = (): string | null => {
     const { fullName, workEmail, organization, projectName, methodology } = formData;
     if (!fullName.trim()) return 'Full name is required.';
-    if (!workEmail.trim()) return 'Work email is required.';
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(workEmail.trim())) return 'Please enter a valid email address.';
+    if (!isInternal && !workEmail.trim()) return 'Work email is required.';
+    if (workEmail.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(workEmail.trim())) return 'Please enter a valid email address.';
     if (!organization.trim()) return 'Organization is required.';
     if (!projectName.trim()) return 'Project name is required.';
     if (!methodology.trim()) return 'Methodology is required.';
     if (!file) return 'Please select a PDF file.';
-    if (file.type !== 'application/pdf') return 'Only PDF files are accepted.';
-    if (file.size > 50 * 1024 * 1024) return 'File size must be under 50MB.';
-    if (file.size === 0) return 'The selected file is empty.';
-    return null;
+    return isPdfUpload(file);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -87,11 +94,13 @@ const PddUploadForm: React.FC = () => {
           fileName: file!.name,
           contentType: 'application/pdf',
           fileSize: file!.size,
-          fullName: formData.fullName.trim(),
-          workEmail: formData.workEmail.trim(),
+          contactName: formData.fullName.trim(),
+          workEmail: formData.workEmail.trim() || undefined,
           organization: formData.organization.trim(),
           projectName: formData.projectName.trim(),
           methodology: formData.methodology.trim(),
+          submissionSource: isInternal ? formData.submissionSource : 'website',
+          externalContact: isInternal ? formData.externalContact.trim() || undefined : undefined,
           note: formData.note.trim(),
         }),
       });
@@ -125,6 +134,7 @@ const PddUploadForm: React.FC = () => {
       try {
         uploadRes = await fetch(uploadUrl, {
           method: 'PUT',
+          headers: { 'Content-Type': 'application/pdf' },
           body: file,
         });
       } catch (r2Err) {
@@ -171,11 +181,14 @@ const PddUploadForm: React.FC = () => {
         body: JSON.stringify({
           key,
           fileName: file!.name,
-          fullName: formData.fullName.trim(),
-          workEmail: formData.workEmail.trim(),
+          fileSize: file!.size,
+          contactName: formData.fullName.trim(),
+          workEmail: formData.workEmail.trim() || undefined,
           organization: formData.organization.trim(),
           projectName: formData.projectName.trim(),
           methodology: formData.methodology.trim(),
+          submissionSource: isInternal ? formData.submissionSource : 'website',
+          externalContact: isInternal ? formData.externalContact.trim() || undefined : undefined,
           note: formData.note.trim(),
         }),
       });
@@ -215,8 +228,9 @@ const PddUploadForm: React.FC = () => {
         </div>
         <h3 className="mt-4 text-lg font-semibold text-forest-800">Submission received</h3>
         <p className="mt-2 text-sm text-gray-600 max-w-md mx-auto">
-          Your PDD has been submitted for scope review. We will review your project
-          documentation and respond within two business days.
+          {isInternal
+            ? 'The internal submission has been recorded for scope review.'
+            : 'Your PDD has been submitted for scope review. We will review your project documentation and respond within two business days.'}
         </p>
         {submissionId && (
           <p className="mt-3 text-xs text-gray-400">
@@ -227,7 +241,7 @@ const PddUploadForm: React.FC = () => {
           type="button"
           onClick={() => {
             setPhase('idle');
-            setFormData({ fullName: '', workEmail: '', organization: '', projectName: '', methodology: '', note: '' });
+            setFormData({ fullName: '', workEmail: '', organization: '', projectName: '', methodology: '', note: '', externalContact: '', submissionSource: 'internal' });
             setFile(null);
             setFileName('');
             setSubmissionId('');
@@ -289,13 +303,13 @@ const PddUploadForm: React.FC = () => {
           </div>
           <div>
             <label htmlFor="pdd-workEmail" className="mb-1 block text-sm font-medium text-gray-700">
-              Work email <span className="text-forest-600">*</span>
+              Work email {!isInternal && <span className="text-forest-600">*</span>}
             </label>
             <input
               id="pdd-workEmail"
               name="workEmail"
               type="email"
-              required
+              required={!isInternal}
               placeholder="you@organization.com"
               className={inputClasses}
               value={formData.workEmail}
@@ -354,6 +368,24 @@ const PddUploadForm: React.FC = () => {
           />
         </div>
 
+        {isInternal && (
+          <>
+            <div>
+              <label htmlFor="pdd-submissionSource" className="mb-1 block text-sm font-medium text-gray-700">Submission source <span className="text-forest-600">*</span></label>
+              <select id="pdd-submissionSource" className={inputClasses} value={formData.submissionSource} onChange={(e) => handleChange('submissionSource', e.target.value as FormFields['submissionSource'])} disabled={phase === 'uploading'}>
+                <option value="whatsapp">WhatsApp</option>
+                <option value="email">Email</option>
+                <option value="internal">Internal</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="pdd-externalContact" className="mb-1 block text-sm font-medium text-gray-700">External contact</label>
+              <input id="pdd-externalContact" type="text" placeholder="Phone, WhatsApp ID, or source note" className={inputClasses} value={formData.externalContact} onChange={(e) => handleChange('externalContact', e.target.value)} disabled={phase === 'uploading'} />
+            </div>
+          </>
+        )}
+
         <div>
           <label htmlFor="pdd-file" className="mb-1 block text-sm font-medium text-gray-700">
             PDD upload <span className="text-forest-600">*</span>
@@ -385,7 +417,7 @@ const PddUploadForm: React.FC = () => {
             </button>
           </div>
           <p className="mt-1.5 text-xs text-gray-400">
-            Accepted file type: PDF. Maximum size: 50MB.
+            Accepted file type: PDF. Maximum size: {MAX_FILE_SIZE / (1024 * 1024)}MB. {isInternal && fileName && file && `Selected: ${fileName} (${(file.size / (1024 * 1024)).toFixed(2)} MB)`}
           </p>
         </div>
 
@@ -419,7 +451,7 @@ const PddUploadForm: React.FC = () => {
               Uploading and submitting...
             </span>
           ) : (
-            'Submit PDD for Scope Review'
+            isInternal ? 'Record Internal PDD Submission' : 'Submit PDD for Scope Review'
           )}
         </button>
 

--- a/components/preview/PddUploadForm.tsx
+++ b/components/preview/PddUploadForm.tsx
@@ -170,7 +170,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
       if (!uploadRes.ok) {
         const r2ErrorText = await uploadRes.text().catch(() => '');
         console.error('[PddUploadForm] R2 PUT failed', { status: uploadRes.status, body: r2ErrorText });
-        throw new Error('File upload failed. Please try again.');
+        throw new Error(`File upload failed: R2 returned HTTP ${uploadRes.status}${uploadRes.statusText ? ` (${uploadRes.statusText})` : ''}. Please try again.`);
       }
 
       console.info('[PddUploadForm] Step 3: Confirming submission', { key: key.slice(0, 30) + '...' });

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,6 +1,6 @@
 interface SubmissionEmailParams {
-  fullName: string;
-  workEmail: string;
+  contactName: string;
+  workEmail?: string;
   organization: string;
   projectName: string;
   methodology: string;
@@ -8,23 +8,28 @@ interface SubmissionEmailParams {
   fileName: string;
   submissionId: string;
   timestamp: string;
+  submissionSource: string;
+  externalContact?: string;
 }
 
-function buildEmailText(params: SubmissionEmailParams): string {
+export function buildEmailText(params: SubmissionEmailParams): string {
   const lines = [
     "New evidence readiness assessment request.",
     "",
     "Contact:",
     "",
-    `Name:          ${params.fullName}`,
-    `Email:         ${params.workEmail}`,
+    `Name:          ${params.contactName}`,
+    `Email:         ${params.workEmail || "Not provided"}`,
     `Organization:  ${params.organization}`,
     `Project:       ${params.projectName}`,
     `Methodology:   ${params.methodology}`,
+    `Source:        ${params.submissionSource}`,
     `Reference ID:  ${params.submissionId}`,
     `File:          ${params.fileName}`,
     `Submitted:     ${params.timestamp}`,
   ];
+
+  if (params.externalContact) lines.push(`External contact: ${params.externalContact}`);
 
   if (params.note) {
     lines.push("", `Additional note: ${params.note}`);

--- a/lib/internal-auth.ts
+++ b/lib/internal-auth.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest } from "next";
+
+export const INTERNAL_SESSION_COOKIE = "article6_internal_upload";
+const SESSION_MAX_AGE_SECONDS = 8 * 60 * 60;
+
+function encode(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function toBase64Url(bytes: ArrayBuffer): string {
+  let binary = "";
+  new Uint8Array(bytes).forEach((byte) => { binary += String.fromCharCode(byte); });
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function signature(payload: string, secret: string): Promise<string> {
+  const key = await globalThis.crypto.subtle.importKey(
+    "raw", encode(secret) as BufferSource, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
+  );
+  return toBase64Url(await globalThis.crypto.subtle.sign("HMAC", key, encode(payload) as BufferSource));
+}
+
+export async function createInternalSessionToken(username: string, secret: string, now = Date.now()): Promise<string> {
+  const timestamp = String(now);
+  return `${timestamp}.${await signature(`${username}.${timestamp}`, secret)}`;
+}
+
+export async function isValidInternalSessionToken(token: string | undefined, username: string, secret: string, now = Date.now()): Promise<boolean> {
+  if (!token || !username || !secret) return false;
+  const [timestamp, providedSignature] = token.split(".");
+  const issuedAt = Number(timestamp);
+  if (!timestamp || !providedSignature || !Number.isFinite(issuedAt) || now - issuedAt > SESSION_MAX_AGE_SECONDS * 1000 || issuedAt > now + 60_000) return false;
+  const expected = await signature(`${username}.${timestamp}`, secret);
+  return expected === providedSignature;
+}
+
+export async function hasInternalUploadSession(req: NextApiRequest): Promise<boolean> {
+  const cookieHeader = req.headers.cookie || "";
+  const token = cookieHeader.split(";").map((part) => part.trim()).find((part) => part.startsWith(`${INTERNAL_SESSION_COOKIE}=`))?.split("=").slice(1).join("=");
+  return isValidInternalSessionToken(token, process.env.INTERNAL_UPLOAD_USERNAME || "", process.env.INTERNAL_UPLOAD_PASSWORD || "");
+}

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "crypto";
 import { S3Client, PutObjectCommand, HeadObjectCommand, PutBucketCorsCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { PDF_CONTENT_TYPE } from "./submissions";
+
+const PDF_CONTENT_TYPE = "application/pdf";
 
 function getR2Credentials() {
   const accountId = process.env.R2_ACCOUNT_ID;
@@ -24,6 +25,8 @@ function getS3Client(): S3Client {
   return new S3Client({
     region: "auto",
     endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    requestChecksumCalculation: "WHEN_REQUIRED",
+    responseChecksumValidation: "WHEN_REQUIRED",
     credentials: {
       accessKeyId,
       secretAccessKey,

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { S3Client, PutObjectCommand, HeadObjectCommand, PutBucketCorsCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { PDF_CONTENT_TYPE } from "./submissions";
 
 function getR2Credentials() {
   const accountId = process.env.R2_ACCOUNT_ID;
@@ -30,14 +31,13 @@ function getS3Client(): S3Client {
   });
 }
 
-function generateKey(fileName: string): string {
+function generateKey(): string {
   const now = new Date();
   const yyyy = now.getFullYear();
   const mm = String(now.getMonth() + 1).padStart(2, "0");
   const dd = String(now.getDate()).padStart(2, "0");
   const uuid = randomUUID();
-  const safeName = fileName.replace(/[^a-zA-Z0-9._-]/g, "_");
-  return `submissions/${yyyy}/${mm}/${dd}/${uuid}-${safeName}`;
+  return `submissions/${yyyy}-${mm}-${dd}/${uuid}.pdf`;
 }
 
 export async function configureBucketCors(): Promise<void> {
@@ -66,16 +66,17 @@ export async function configureBucketCors(): Promise<void> {
   console.info("[r2] CORS configuration applied", { bucket: bucketName });
 }
 
-export async function generatePresignedUploadUrl(fileName: string): Promise<{ uploadUrl: string; key: string }> {
+export async function generatePresignedUploadUrl(): Promise<{ uploadUrl: string; key: string }> {
   const s3 = getS3Client();
   const { bucketName } = getR2Credentials();
-  const key = generateKey(fileName);
+  const key = generateKey();
 
   console.info("[r2] Generating presigned PUT URL", { bucket: bucketName, key });
 
   const command = new PutObjectCommand({
     Bucket: bucketName,
     Key: key,
+    ContentType: PDF_CONTENT_TYPE,
   });
 
   const uploadUrl = await getSignedUrl(s3, command, {

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -1,0 +1,87 @@
+export const MAX_FILE_SIZE = 50 * 1024 * 1024;
+export const PDF_CONTENT_TYPE = "application/pdf";
+
+export type SubmissionSource = "website" | "whatsapp" | "email" | "internal" | "other";
+
+export interface SubmissionMetadata {
+  contactName: string;
+  workEmail?: string;
+  organization: string;
+  projectName: string;
+  methodology: string;
+  submissionSource: SubmissionSource;
+  externalContact?: string;
+  note?: string;
+  fileName: string;
+  fileSize: number;
+}
+
+export const NON_WEBSITE_SOURCES: SubmissionSource[] = ["whatsapp", "email", "internal", "other"];
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function validateSubmissionMetadata(
+  input: Partial<SubmissionMetadata> & { submissionSource?: unknown }
+): string | null {
+  const value = input as Partial<SubmissionMetadata>;
+  if (typeof value.submissionSource !== "string" || !["website", ...NON_WEBSITE_SOURCES].includes(value.submissionSource)) {
+    return "Invalid submission source.";
+  }
+  if (typeof value.contactName !== "string" || !value.contactName.trim() || value.contactName.length > 200) {
+    return "Contact name is required (max 200 characters).";
+  }
+  if (value.submissionSource === "website" && (!value.workEmail || !value.workEmail.trim())) {
+    return "A valid work email is required.";
+  }
+  if (value.workEmail !== undefined && value.workEmail !== "" && (typeof value.workEmail !== "string" || value.workEmail.length > 320 || !EMAIL_PATTERN.test(value.workEmail.trim()))) {
+    return "Please enter a valid email address.";
+  }
+  if (typeof value.organization !== "string" || !value.organization.trim() || value.organization.length > 200) {
+    return "Organization is required (max 200 characters).";
+  }
+  if (typeof value.projectName !== "string" || !value.projectName.trim() || value.projectName.length > 300) {
+    return "Project name is required (max 300 characters).";
+  }
+  if (typeof value.methodology !== "string" || !value.methodology.trim() || value.methodology.length > 200) {
+    return "Methodology is required (max 200 characters).";
+  }
+  if (value.externalContact !== undefined && (typeof value.externalContact !== "string" || value.externalContact.length > 320)) {
+    return "External contact must be under 320 characters.";
+  }
+  if (value.note !== undefined && (typeof value.note !== "string" || value.note.length > 2000)) {
+    return "Note must be under 2000 characters.";
+  }
+  if (typeof value.fileName !== "string" || !value.fileName.trim() || value.fileName.length > 500) {
+    return "File name is required (max 500 characters).";
+  }
+  if (typeof value.fileSize !== "number" || !Number.isFinite(value.fileSize) || value.fileSize <= 0) {
+    return "Invalid file size.";
+  }
+  if (value.fileSize > MAX_FILE_SIZE) {
+    return "File size must be under 50MB.";
+  }
+  return null;
+}
+
+export function isPdfUpload(file: { type: string; size: number }): string | null {
+  if (file.type !== PDF_CONTENT_TYPE) return "Only PDF files are accepted.";
+  if (file.size <= 0) return "The selected file is empty.";
+  if (file.size > MAX_FILE_SIZE) return "File size must be under 50MB.";
+  return null;
+}
+
+export function isApprovedSubmissionKey(key: unknown): boolean {
+  return typeof key === "string" && /^submissions\/\d{4}-\d{2}-\d{2}\/[0-9a-f-]{36}\.pdf$/.test(key);
+}
+
+export function validateStoredObject(
+  object: { exists: boolean; size: number; contentType?: string },
+  declaredSize: number
+): string | null {
+  if (!object.exists) return "Uploaded file not found.";
+  if (object.size <= 0) return "Uploaded file is empty.";
+  if (object.size > MAX_FILE_SIZE) return "Uploaded file exceeds the 50MB limit.";
+  if (object.size !== declaredSize) return "Uploaded file size does not match the declared file size.";
+  if (object.contentType && object.contentType !== PDF_CONTENT_TYPE) return "Uploaded file is not a valid PDF.";
+  return null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createInternalSessionToken, INTERNAL_SESSION_COOKIE } from "./lib/internal-auth";
+
+export const config = { matcher: ["/internal/:path*"] };
+
+export default async function middleware(request: NextRequest) {
+  const username = process.env.INTERNAL_UPLOAD_USERNAME;
+  const password = process.env.INTERNAL_UPLOAD_PASSWORD;
+  if (!username || !password) {
+    return new NextResponse("Internal upload protection is not configured.", { status: 503 });
+  }
+
+  const authorization = request.headers.get("authorization");
+  if (!authorization?.startsWith("Basic ")) {
+    return new NextResponse("Authentication required.", {
+      status: 401,
+      headers: { "WWW-Authenticate": 'Basic realm="Article6 internal uploads", charset="UTF-8"' },
+    });
+  }
+
+  let suppliedUsername = "";
+  let suppliedPassword = "";
+  try {
+    const decoded = atob(authorization.slice(6));
+    const separator = decoded.indexOf(":");
+    suppliedUsername = decoded.slice(0, separator);
+    suppliedPassword = decoded.slice(separator + 1);
+  } catch {
+    suppliedUsername = "";
+  }
+
+  if (suppliedUsername !== username || suppliedPassword !== password) {
+    return new NextResponse("Invalid credentials.", {
+      status: 401,
+      headers: { "WWW-Authenticate": 'Basic realm="Article6 internal uploads", charset="UTF-8"' },
+    });
+  }
+
+  const response = NextResponse.next();
+  response.cookies.set(INTERNAL_SESSION_COOKIE, await createInternalSessionToken(username, password), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict",
+    path: "/",
+    maxAge: 8 * 60 * 60,
+  });
+  return response;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --experimental-strip-types --test tests/**/*.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1095.0",

--- a/pages/api/upload/confirm.ts
+++ b/pages/api/upload/confirm.ts
@@ -2,44 +2,28 @@ import { randomUUID } from "crypto";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getBucketName, verifyObjectExists } from "../../../lib/r2";
 import { sendSubmissionNotification } from "../../../lib/email";
+import { hasInternalUploadSession } from "../../../lib/internal-auth";
+import { isApprovedSubmissionKey, validateStoredObject, validateSubmissionMetadata, type SubmissionSource } from "../../../lib/submissions";
 
 interface ConfirmRequestBody {
   key: string;
   fileName: string;
-  fullName: string;
-  workEmail: string;
+  fileSize: number;
+  contactName: string;
+  workEmail?: string;
   organization: string;
   projectName: string;
   methodology: string;
+  submissionSource: SubmissionSource;
+  externalContact?: string;
   note?: string;
 }
 
-function validate(body: ConfirmRequestBody): string | null {
-  if (!body.key || typeof body.key !== "string" || body.key.length > 1000) {
-    return "Invalid upload key.";
-  }
-  if (!body.key.startsWith("submissions/")) {
+export function validateConfirmRequest(body: Partial<ConfirmRequestBody>): string | null {
+  if (!isApprovedSubmissionKey(body.key)) {
     return "Invalid upload key prefix.";
   }
-  if (!body.fileName || typeof body.fileName !== "string" || body.fileName.length > 500) {
-    return "File name is required.";
-  }
-  if (!body.fullName || typeof body.fullName !== "string" || body.fullName.length > 200) {
-    return "Full name is required.";
-  }
-  if (!body.workEmail || typeof body.workEmail !== "string" || body.workEmail.length > 320) {
-    return "Work email is required.";
-  }
-  if (!body.organization || typeof body.organization !== "string" || body.organization.length > 200) {
-    return "Organization is required.";
-  }
-  if (!body.projectName || typeof body.projectName !== "string" || body.projectName.length > 300) {
-    return "Project name is required.";
-  }
-  if (!body.methodology || typeof body.methodology !== "string" || body.methodology.length > 200) {
-    return "Methodology is required.";
-  }
-  return null;
+  return validateSubmissionMetadata(body);
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -48,96 +32,60 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const body = req.body as ConfirmRequestBody;
+  const body = req.body as Partial<ConfirmRequestBody>;
+  const validationError = validateConfirmRequest(body);
+  if (validationError) return res.status(400).json({ error: validationError });
 
-  const validationError = validate(body);
-  if (validationError) {
-    return res.status(400).json({ error: validationError });
+  if (body.submissionSource !== "website" && !(await hasInternalUploadSession(req))) {
+    return res.status(401).json({ error: "Internal upload authentication required." });
   }
 
   try {
-    const bucketName = getBucketName();
-    console.info("[confirm] Verifying uploaded object", { key: body.key.slice(0, 40) + "...", bucket: bucketName });
-
-    const verification = await verifyObjectExists(body.key);
-
-    console.info("[confirm] Object verification result", {
-      exists: verification.exists,
-      size: verification.size,
-      contentType: verification.contentType,
-      lastModified: verification.lastModified,
-    });
-
-    if (!verification.exists) {
-      return res.status(400).json({
-        error: "Uploaded file not found. The file may have expired or was not uploaded successfully.",
-      });
-    }
-
-    if (verification.size === 0) {
-      return res.status(400).json({
-        error: "Uploaded file is empty. Please upload a valid PDF file.",
-      });
-    }
-
-    if (verification.contentType && verification.contentType !== "application/pdf") {
-      return res.status(400).json({
-        error: "Uploaded file is not a valid PDF.",
-      });
-    }
+    const verification = await verifyObjectExists(body.key as string);
+    const storedObjectError = validateStoredObject(verification, body.fileSize!);
+    if (storedObjectError) return res.status(400).json({ error: storedObjectError });
 
     const submissionId = randomUUID();
     const timestamp = new Date().toISOString();
-
     const submission = {
       id: submissionId,
       timestamp,
       key: body.key,
-      bucket: bucketName,
-      fileName: body.fileName.trim(),
+      bucket: getBucketName(),
+      fileName: body.fileName!.trim(),
       fileSize: verification.size,
-      fullName: body.fullName.trim(),
-      workEmail: body.workEmail.trim().toLowerCase(),
-      organization: body.organization.trim(),
-      projectName: body.projectName.trim(),
-      methodology: body.methodology.trim(),
-      note: body.note ? body.note.trim() : "",
+      contactName: body.contactName!.trim(),
+      workEmail: body.workEmail?.trim().toLowerCase() || undefined,
+      organization: body.organization!.trim(),
+      projectName: body.projectName!.trim(),
+      methodology: body.methodology!.trim(),
+      submissionSource: body.submissionSource,
+      externalContact: body.externalContact?.trim() || undefined,
+      note: body.note?.trim() || "",
     };
 
     console.log("[Submission Confirmed]", JSON.stringify(submission, null, 2));
-
-    console.info("[confirm] Sending Resend notification", {
-      to: process.env.ADMIN_NOTIFICATION_EMAIL || "contact@article6.org",
-      resendKey: process.env.RESEND_API_KEY ? "set" : "MISSING",
-    });
-
-    const emailSent = await sendSubmissionNotification({
-      fullName: submission.fullName,
+    await sendSubmissionNotification({
+      contactName: submission.contactName,
       workEmail: submission.workEmail,
       organization: submission.organization,
       projectName: submission.projectName,
       methodology: submission.methodology,
+      submissionSource: submission.submissionSource!,
+      externalContact: submission.externalContact,
       note: submission.note,
       fileName: submission.fileName,
       submissionId: submission.id,
       timestamp: submission.timestamp,
     });
 
-    console.info("[confirm] Email notification result", { emailSent, submissionId: submission.id });
-
     return res.status(200).json({
       success: true,
-      submissionId: submission.id,
-      message: "Your PDD has been submitted for scope review. We will respond within two business days.",
+      submissionId,
+      message: body.submissionSource === "website" ? "Your PDD has been submitted for scope review. We will respond within two business days." : "Internal PDD submission received.",
     });
   } catch (err) {
-    console.error("[confirm] Error confirming submission:", {
-      error: err instanceof Error ? err.message : String(err),
-      key: body.key,
-      r2AccountId: process.env.R2_ACCOUNT_ID ? "set" : "MISSING",
-    });
-    return res.status(500).json({
-      error: "Failed to confirm submission. Please contact us at contact@article6.org.",
-    });
+    console.error("[confirm] Error confirming submission:", err instanceof Error ? err.message : String(err));
+    return res.status(500).json({ error: "Failed to confirm submission. Please contact us at contact@article6.org." });
   }
 }

--- a/pages/api/upload/presign.ts
+++ b/pages/api/upload/presign.ts
@@ -1,56 +1,26 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { configureBucketCors, generatePresignedUploadUrl, getBucketName } from "../../../lib/r2";
-
-const ALLOWED_CONTENT_TYPE = "application/pdf";
-const MAX_FILE_SIZE_MB = 50;
+import { configureBucketCors, generatePresignedUploadUrl } from "../../../lib/r2";
+import { hasInternalUploadSession } from "../../../lib/internal-auth";
+import { PDF_CONTENT_TYPE, validateSubmissionMetadata, type SubmissionSource } from "../../../lib/submissions";
 
 interface PresignRequestBody {
   fileName: string;
   contentType: string;
   fileSize: number;
-  fullName: string;
-  workEmail: string;
+  contactName: string;
+  workEmail?: string;
   organization: string;
   projectName: string;
   methodology: string;
+  submissionSource: SubmissionSource;
+  externalContact?: string;
   note?: string;
 }
 
-function validate(body: PresignRequestBody): string | null {
-  if (!body.fileName || typeof body.fileName !== "string") {
-    return "File name is required.";
-  }
-  if (body.fileName.length > 500) {
-    return "File name is too long.";
-  }
-  if (body.contentType !== ALLOWED_CONTENT_TYPE) {
-    return "Only PDF files are accepted.";
-  }
-  if (typeof body.fileSize !== "number" || body.fileSize <= 0) {
-    return "Invalid file size.";
-  }
-  if (body.fileSize > MAX_FILE_SIZE_MB * 1024 * 1024) {
-    return `File size must be under ${MAX_FILE_SIZE_MB}MB.`;
-  }
-  if (!body.fullName || typeof body.fullName !== "string" || body.fullName.length > 200) {
-    return "Full name is required (max 200 characters).";
-  }
-  if (!body.workEmail || typeof body.workEmail !== "string" || body.workEmail.length > 320) {
-    return "A valid work email is required.";
-  }
-  if (!body.organization || typeof body.organization !== "string" || body.organization.length > 200) {
-    return "Organization is required (max 200 characters).";
-  }
-  if (!body.projectName || typeof body.projectName !== "string" || body.projectName.length > 300) {
-    return "Project name is required (max 300 characters).";
-  }
-  if (!body.methodology || typeof body.methodology !== "string" || body.methodology.length > 200) {
-    return "Methodology is required (max 200 characters).";
-  }
-  if (body.note && body.note.length > 2000) {
-    return "Note must be under 2000 characters.";
-  }
-  return null;
+export function validatePresignRequest(body: Partial<PresignRequestBody>): string | null {
+  if (body.contentType !== PDF_CONTENT_TYPE) return "Only PDF files are accepted.";
+  const error = validateSubmissionMetadata(body);
+  return error;
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -59,86 +29,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const body = req.body as PresignRequestBody;
+  const body = req.body as Partial<PresignRequestBody>;
+  const validationError = validatePresignRequest(body);
+  if (validationError) return res.status(400).json({ error: validationError });
 
-  const validationError = validate(body);
-  if (validationError) {
-    return res.status(400).json({ error: validationError });
+  if (body.submissionSource !== "website" && !(await hasInternalUploadSession(req))) {
+    return res.status(401).json({ error: "Internal upload authentication required." });
   }
 
   try {
     try {
       await configureBucketCors();
     } catch (corsErr) {
-      console.warn("[presign] CORS configuration skipped (token may lack PutBucketCors permission):", {
-        error: corsErr instanceof Error ? corsErr.message : String(corsErr),
-        bucket: process.env.R2_BUCKET_NAME,
-      });
+      console.warn("[presign] CORS configuration skipped:", corsErr instanceof Error ? corsErr.message : String(corsErr));
     }
 
-    console.info("[presign] Generating presigned URL", {
-      fileName: body.fileName,
-      fileSize: body.fileSize,
-      contentType: body.contentType,
-      bucket: process.env.R2_BUCKET_NAME || "not set",
-    });
-
-    const { uploadUrl, key } = await generatePresignedUploadUrl(body.fileName);
-
-    console.info("[presign] Successfully generated presigned URL", {
-      key: key.slice(0, 40) + "...",
-      urlHost: new URL(uploadUrl).hostname,
-      urlPath: new URL(uploadUrl).pathname.slice(0, 60) + "...",
-      urlProtocol: new URL(uploadUrl).protocol,
-      hasBucketInPath: new URL(uploadUrl).pathname.includes(getBucketName()),
-      signedHeadersParam: new URLSearchParams(new URL(uploadUrl).search).get("X-Amz-SignedHeaders") || "none",
-    });
-
-    const bucketName = getBucketName();
-    const accountId = process.env.R2_ACCOUNT_ID!;
-
-    try {
-      const corsTestUrl = `https://${bucketName}.${accountId}.r2.cloudflarestorage.com/submissions/cors-test.txt`;
-      const optRes = await fetch(corsTestUrl, {
-        method: "OPTIONS",
-        headers: {
-          Origin: "https://article6.org",
-          "Access-Control-Request-Method": "PUT",
-        },
-      });
-      const corsHeaders: Record<string, string> = {};
-      optRes.headers.forEach((v, k) => {
-        if (k.toLowerCase().startsWith("access-control")) {
-          corsHeaders[k] = v;
-        }
-      });
-      console.info("[presign] R2 CORS diagnostic", {
-        testUrl: corsTestUrl.slice(0, 100),
-        optStatus: optRes.status,
-        corsHeaders,
-      });
-    } catch (corsDiagErr) {
-      console.error("[presign] R2 CORS diagnostic failed:", {
-        error: corsDiagErr instanceof Error ? corsDiagErr.message : String(corsDiagErr),
-      });
-    }
-
-    return res.status(200).json({
-      uploadUrl,
-      key,
-      expiresIn: 600,
-    });
+    const { uploadUrl, key } = await generatePresignedUploadUrl();
+    return res.status(200).json({ uploadUrl, key, expiresIn: 600 });
   } catch (err) {
-    console.error("[presign] Error generating presigned URL:", {
-      error: err instanceof Error ? err.message : String(err),
-      fileName: body.fileName,
-      r2AccountId: process.env.R2_ACCOUNT_ID ? "set" : "MISSING",
-      r2AccessKey: process.env.R2_ACCESS_KEY_ID ? "set" : "MISSING",
-      r2Secret: process.env.R2_SECRET_ACCESS_KEY ? "set" : "MISSING",
-      r2Bucket: process.env.R2_BUCKET_NAME ? "set" : "MISSING",
-    });
-    return res.status(500).json({
-      error: "Failed to generate upload URL. Please try again later.",
-    });
+    console.error("[presign] Error generating upload URL:", err instanceof Error ? err.message : String(err));
+    return res.status(500).json({ error: "Failed to generate upload URL. Please try again later." });
   }
 }

--- a/pages/internal/submissions/new.tsx
+++ b/pages/internal/submissions/new.tsx
@@ -1,0 +1,25 @@
+import Head from "next/head";
+import PddUploadForm from "../../../components/preview/PddUploadForm";
+
+export default function NewInternalSubmissionPage() {
+  return (
+    <>
+      <Head>
+        <title>Internal PDD submission | Article6</title>
+        <meta name="robots" content="noindex,nofollow" />
+      </Head>
+      <main className="min-h-screen bg-gray-50 px-4 py-12 text-gray-900">
+        <div className="mx-auto max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-wide text-forest-700">Article6 internal tool</p>
+          <h1 className="mt-2 text-2xl font-bold tracking-tight">Record an internal PDD submission</h1>
+          <p className="mt-3 text-sm leading-relaxed text-gray-600">
+            Use this protected form for documents received outside the public website. The PDF uploads directly to the private R2 bucket.
+          </p>
+          <div className="mt-8 rounded-lg border border-gray-200 bg-white p-5 shadow-sm md:p-7">
+            <PddUploadForm mode="internal" />
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/tests/submissions.test.ts
+++ b/tests/submissions.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildEmailText } from "../lib/email.ts";
+import {
+  isApprovedSubmissionKey,
+  isPdfUpload,
+  MAX_FILE_SIZE,
+  validateStoredObject,
+  validateSubmissionMetadata,
+} from "../lib/submissions.ts";
+
+const base = {
+  contactName: "Synthetic Contact",
+  organization: "Synthetic Organization",
+  projectName: "Synthetic Project",
+  methodology: "Synthetic Methodology",
+  fileName: "synthetic.pdf",
+  fileSize: 1234,
+};
+
+test("internal WhatsApp submission may omit workEmail", () => {
+  assert.equal(validateSubmissionMetadata({ ...base, submissionSource: "whatsapp" }), null);
+});
+
+test("website submission requires a work email", () => {
+  assert.match(validateSubmissionMetadata({ ...base, submissionSource: "website" }) || "", /email/i);
+});
+
+test("optional email is validated when supplied", () => {
+  assert.match(validateSubmissionMetadata({ ...base, submissionSource: "internal", workEmail: "not-an-email" }) || "", /email/i);
+  assert.equal(validateSubmissionMetadata({ ...base, submissionSource: "internal", workEmail: "operator@example.test" }), null);
+});
+
+test("file size boundaries, empty files, and content type are enforced", () => {
+  assert.equal(validateSubmissionMetadata({ ...base, submissionSource: "internal", fileSize: MAX_FILE_SIZE - 1 }), null);
+  assert.match(validateSubmissionMetadata({ ...base, submissionSource: "internal", fileSize: MAX_FILE_SIZE + 1 }) || "", /50MB/i);
+  assert.match(isPdfUpload({ type: "application/pdf", size: 0 }) || "", /empty/i);
+  assert.match(isPdfUpload({ type: "text/plain", size: 10 }) || "", /PDF/i);
+});
+
+test("invalid submission source is rejected", () => {
+  assert.match(validateSubmissionMetadata({ ...base, submissionSource: "fax" as never }) || "", /source/i);
+});
+
+test("only opaque submission keys are approved", () => {
+  assert.equal(isApprovedSubmissionKey("submissions/2026-08-01/123e4567-e89b-12d3-a456-426614174000.pdf"), true);
+  assert.equal(isApprovedSubmissionKey("other/2026-08-01/123e4567-e89b-12d3-a456-426614174000.pdf"), false);
+  assert.equal(isApprovedSubmissionKey("submissions/2026-08-01/123e4567-e89b-12d3-a456-426614174000-client.pdf"), false);
+});
+
+test("confirmation rejects missing, mismatched, oversized, and non-PDF objects", () => {
+  assert.match(validateStoredObject({ exists: false, size: 0 }, 1) || "", /not found/i);
+  assert.match(validateStoredObject({ exists: true, size: 100 }, 99) || "", /match/i);
+  assert.match(validateStoredObject({ exists: true, size: MAX_FILE_SIZE + 1 }, MAX_FILE_SIZE + 1) || "", /50MB/i);
+  assert.match(validateStoredObject({ exists: true, size: 100, contentType: "text/plain" }, 100) || "", /PDF/i);
+});
+
+test("internal notification text works without workEmail and identifies source", () => {
+  const text = buildEmailText({
+    contactName: "Synthetic Contact",
+    organization: "Synthetic Organization",
+    projectName: "Synthetic Project",
+    methodology: "Synthetic Methodology",
+    note: "",
+    fileName: "synthetic.pdf",
+    submissionId: "synthetic-reference",
+    timestamp: "2026-08-01T00:00:00.000Z",
+    submissionSource: "whatsapp",
+  });
+  assert.match(text, /Source:\s+whatsapp/);
+  assert.match(text, /Email:\s+Not provided/);
+});

--- a/tests/submissions.test.ts
+++ b/tests/submissions.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { buildEmailText } from "../lib/email.ts";
+import { generatePresignedUploadUrl } from "../lib/r2.ts";
 import {
   isApprovedSubmissionKey,
   isPdfUpload,
@@ -69,4 +70,16 @@ test("internal notification text works without workEmail and identifies source",
   });
   assert.match(text, /Source:\s+whatsapp/);
   assert.match(text, /Email:\s+Not provided/);
+});
+
+test("presigned browser PUT URLs do not include automatic checksum parameters", async () => {
+  process.env.R2_ACCOUNT_ID = "synthetic-account";
+  process.env.R2_ACCESS_KEY_ID = "synthetic-access-key";
+  process.env.R2_SECRET_ACCESS_KEY = "synthetic-secret-key";
+  process.env.R2_BUCKET_NAME = "synthetic-private-bucket";
+
+  const { uploadUrl } = await generatePresignedUploadUrl();
+  const query = new URL(uploadUrl).searchParams;
+  assert.equal(query.has("x-amz-checksum-crc32"), false);
+  assert.equal(query.has("x-amz-sdk-checksum-algorithm"), false);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
## Summary
Adds a protected internal/manual PDD submission workflow at `/internal/submissions/new` for PDFs received through WhatsApp, email, or other internal channels.

## Architecture
- Reuses browser → presigned PUT URL → private Cloudflare R2 → confirmation.
- PDF bytes never pass through a Next.js API request body.
- Adds shared metadata/file validation and a single `50 * 1024 * 1024` limit.
- Uses opaque `submissions/YYYY-MM-DD/<uuid>.pdf` keys with no customer metadata.
- Confirmation verifies R2 existence, approved key, size, limit, and PDF content type.
- Internal notifications include the source and tolerate a missing work email.

## Protection model and limitation
The internal route is protected by server-side HTTP Basic Auth using `INTERNAL_UPLOAD_USERNAME` and `INTERNAL_UPLOAD_PASSWORD`. Successful access receives an eight-hour HttpOnly, SameSite session cookie; non-website upload API requests require that cookie. Credentials are shared operator credentials rather than a user-management system and must remain server-only. The page is not linked from public navigation and sends `noindex,nofollow`, but URL hiding is not the protection.

Preview and production R2 storage are isolated only if their deployment environments use different `R2_BUCKET_NAME` values. This change does not create or change buckets; verify configured values before using sensitive documents in preview.

## Manual preview test steps

### A. Internal upload without email
1. Open the protected `/internal/submissions/new` route and authenticate.
2. Enter synthetic contact, organization, project, methodology, and note values.
3. Select `WhatsApp`, leave `workEmail` blank, and enter a synthetic external contact.
4. Select a synthetic PDF below 50 MB and upload.
5. Confirm the success state and reference ID.
6. Confirm the object exists in the configured private R2 bucket under `submissions/YYYY-MM-DD/<uuid>.pdf`.
7. Confirm the internal notification was sent and identifies `whatsapp` without attempting a blank recipient.

### B. Large-file test
1. Upload a disposable PDF between 45 MB and 50 MB.
2. Confirm the browser sends the PDF directly to R2 via the presigned PUT URL.
3. Confirm no Next.js API request contains the PDF body.
4. Confirm the R2 object size equals the local file size.

### C. Public regression test
1. Open the existing public upload form on `/`.
2. Verify `workEmail` remains required and invalid/blank values are rejected.
3. Verify a normal public submission still completes with the existing customer-facing success behavior and notification.

### D. Security test
1. Verify `/internal/submissions/new` returns an authentication challenge without the configured protection and cannot be used without valid credentials.
2. Verify no permanent public R2 URL is returned by presign or confirm.
3. Verify the preview deployment writes to the intended configured bucket and does not silently share production storage.

## Validation
- `npm test` — passed (8 focused tests)
- `npx tsc --noEmit` — passed
- `npm run lint` — passed
- `git diff --check` — passed
- `npm run build` — compilation succeeded, but Next build workers did not exit during final type-check phase in the local environment; standalone typecheck passed.

## Environment variables
Existing R2 and Resend variables remain required. Add server-only `INTERNAL_UPLOAD_USERNAME` and `INTERNAL_UPLOAD_PASSWORD`; do not use `NEXT_PUBLIC_*` names. Keep `R2_BUCKET_NAME` private/configured per deployment.