### PR TITLE
fix: isolate internal routes from public layout

### DIFF
--- a/components/InternalLayout.tsx
+++ b/components/InternalLayout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface InternalLayoutProps {
+  children: ReactNode;
+}
+
+export default function InternalLayout({ children }: InternalLayoutProps) {
+  return <div className="min-h-screen bg-gray-50">{children}</div>;
+}

--- a/lib/layout.ts
+++ b/lib/layout.ts
@@ -1,0 +1,7 @@
+export type AppLayoutKind = "marketing" | "preview" | "internal";
+
+export function getAppLayoutKind(pathname: string): AppLayoutKind {
+  if (pathname.startsWith("/internal")) return "internal";
+  if (pathname.startsWith("/preview/verification-readiness")) return "preview";
+  return "marketing";
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,23 +2,29 @@ import Head from 'next/head';
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import Layout from '../components/Layout';
+import InternalLayout from '../components/InternalLayout';
 import PreviewLayout from '../components/preview/PreviewLayout';
+import { getAppLayoutKind } from '../lib/layout';
 
 function MyApp({ Component, pageProps, router }: AppProps) {
-  const isPreview = router.pathname.startsWith('/preview/verification-readiness');
+  const layoutKind = getAppLayoutKind(router.pathname);
 
   return (
     <>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        {isPreview && <meta name="robots" content="noindex,nofollow" />}
+        {layoutKind === 'preview' && <meta name="robots" content="noindex,nofollow" />}
       </Head>
-      {isPreview ? (
+      {layoutKind === 'preview' ? (
         <div style={{ fontFamily: "'Inter', system-ui, -apple-system, sans-serif" }}>
           <PreviewLayout>
             <Component {...pageProps} />
           </PreviewLayout>
         </div>
+      ) : layoutKind === 'internal' ? (
+        <InternalLayout>
+          <Component {...pageProps} />
+        </InternalLayout>
       ) : (
         <Layout>
           <Component {...pageProps} />

--- a/tests/submissions.test.ts
+++ b/tests/submissions.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { buildEmailText } from "../lib/email.ts";
 import { generatePresignedUploadUrl } from "../lib/r2.ts";
+import { getAppLayoutKind } from "../lib/layout.ts";
 import {
   isApprovedSubmissionKey,
   isPdfUpload,
@@ -82,4 +83,11 @@ test("presigned browser PUT URLs do not include automatic checksum parameters", 
   const query = new URL(uploadUrl).searchParams;
   assert.equal(query.has("x-amz-checksum-crc32"), false);
   assert.equal(query.has("x-amz-sdk-checksum-algorithm"), false);
+});
+
+test("public pages use marketing chrome and internal pages do not", () => {
+  assert.equal(getAppLayoutKind("/about-us"), "marketing");
+  assert.equal(getAppLayoutKind("/internal/submissions/new"), "internal");
+  assert.notEqual(getAppLayoutKind("/internal/submissions/new"), "marketing");
+  assert.equal(getAppLayoutKind("/404"), "marketing");
 });


### PR DESCRIPTION
- Adds InternalLayout without the public navbar or footer.
- Routes /internal/* through the private layout in pages/_app.tsx.
- Keeps public and preview layouts unchanged.
- Preserves authentication, metadata, and upload behavior.
- Adds regression coverage for public, internal, and 404 layout classification.

Validation already completed:
- npm test: 10 tests passed
- npx tsc --noEmit: passed
- npm run lint: passed
- git diff --check: passed
- /about-us includes the public navbar
- authenticated /internal/submissions/new returns 200 without the navbar
- /404 remains on the public layout

This PR contains the follow-up layout isolation commit only; the upload flow and internal page design are unchanged.