### PR TITLE
feat: polish submission metadata and email notifications

### DIFF
--- a/components/preview/PddUploadForm.tsx
+++ b/components/preview/PddUploadForm.tsx
@@ -113,7 +113,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
         status: presignRes.status,
         ok: presignRes.ok,
         hasUploadUrl: !!(presignBody as { uploadUrl?: string }).uploadUrl,
-        key: ((presignBody as { key?: string }).key || '').slice(0, 30) + '...',
+        hasUploadReference: !!(presignBody as { uploadReference?: string }).uploadReference,
         error: presignBody.error,
       });
 
@@ -121,12 +121,11 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
         throw new Error(presignBody.error || 'Failed to prepare upload.');
       }
 
-      const { uploadUrl, key } = presignBody as { uploadUrl: string; key: string };
+      const { uploadUrl, uploadReference, submissionReference, uploadHeaders } = presignBody as { uploadUrl: string; uploadReference: string; submissionReference: string; uploadHeaders: Record<string, string> };
 
       console.info('[PddUploadForm] Step 2: Uploading file to R2', {
-        key: key.slice(0, 30) + '...',
+        hasUploadReference: !!uploadReference,
         urlHost: new URL(uploadUrl).hostname,
-        urlPath: new URL(uploadUrl).pathname.slice(0, 50) + '...',
         urlParams: new URL(uploadUrl).search.slice(0, 100) + '...',
         fileSize: file!.size,
         fileType: file!.type,
@@ -136,7 +135,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
       try {
         uploadRes = await fetch(uploadUrl, {
           method: 'PUT',
-          headers: { 'Content-Type': 'application/pdf' },
+          headers: uploadHeaders,
           body: file,
         });
       } catch (r2Err) {
@@ -175,13 +174,14 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
         throw new Error(`File upload failed: R2 returned HTTP ${uploadRes.status}${uploadRes.statusText ? ` (${uploadRes.statusText})` : ''}. Please try again.`);
       }
 
-      console.info('[PddUploadForm] Step 3: Confirming submission', { key: key.slice(0, 30) + '...' });
+      console.info('[PddUploadForm] Step 3: Confirming submission', { submissionReference });
 
       const confirmRes = await fetch('/api/upload/confirm', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          key,
+          uploadReference,
+          submissionReference,
           fileName: file!.name,
           fileSize: file!.size,
           contactName: formData.fullName.trim(),
@@ -201,7 +201,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
         status: confirmRes.status,
         ok: confirmRes.ok,
         success: confirmBody.success,
-        submissionId: confirmBody.submissionId ? (confirmBody.submissionId as string).slice(0, 8) + '...' : undefined,
+        submissionReference: confirmBody.submissionId,
         message: confirmBody.message,
         error: confirmBody.error,
       });
@@ -212,7 +212,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
 
       setSubmissionId(confirmBody.submissionId);
       setPhase('success');
-      console.info('[PddUploadForm] Upload flow complete', { submissionId: confirmBody.submissionId });
+      console.info('[PddUploadForm] Upload flow complete', { submissionReference: confirmBody.submissionId });
     } catch (err) {
       console.error('[PddUploadForm] Upload flow error', err);
       setPhase('error');
@@ -246,7 +246,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
         </p>
         {submissionId && (
           <p className="mt-3 text-xs text-gray-400">
-            Reference: <code className="text-gray-500">{submissionId.slice(0, 8)}</code>
+            Reference: <code className="text-gray-500">{submissionId}</code>
           </p>
         )}
         <button

--- a/components/preview/PddUploadForm.tsx
+++ b/components/preview/PddUploadForm.tsx
@@ -121,7 +121,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
         throw new Error(presignBody.error || 'Failed to prepare upload.');
       }
 
-      const { uploadUrl, uploadReference, submissionReference, uploadHeaders } = presignBody as { uploadUrl: string; uploadReference: string; submissionReference: string; uploadHeaders: Record<string, string> };
+      const { uploadUrl, uploadReference } = presignBody as { uploadUrl: string; uploadReference: string };
 
       console.info('[PddUploadForm] Step 2: Uploading file to R2', {
         hasUploadReference: !!uploadReference,
@@ -135,7 +135,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
       try {
         uploadRes = await fetch(uploadUrl, {
           method: 'PUT',
-          headers: uploadHeaders,
+          headers: { 'Content-Type': 'application/pdf' },
           body: file,
         });
       } catch (r2Err) {
@@ -174,14 +174,13 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
         throw new Error(`File upload failed: R2 returned HTTP ${uploadRes.status}${uploadRes.statusText ? ` (${uploadRes.statusText})` : ''}. Please try again.`);
       }
 
-      console.info('[PddUploadForm] Step 3: Confirming submission', { submissionReference });
+      console.info('[PddUploadForm] Step 3: Confirming submission');
 
       const confirmRes = await fetch('/api/upload/confirm', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           uploadReference,
-          submissionReference,
           fileName: file!.name,
           fileSize: file!.size,
           contactName: formData.fullName.trim(),

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -18,6 +18,9 @@ const escapeHtml = (value: string): string => value.replace(/&/g, "&amp;").repla
 const optional = (value?: string): string => value?.trim() || "Not provided";
 const formatFileSize = (bytes: number): string => `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
 const formatTimestamp = (timestamp: string): string => new Intl.DateTimeFormat("en", { dateStyle: "medium", timeStyle: "short", timeZone: "UTC" }).format(new Date(timestamp)) + " UTC";
+export function normalizeEmailSubjectProject(value: string): string {
+  return value.replace(/[\u0000-\u001f\u007f]/g, " ").replace(/\s+/g, " ").trim().slice(0, 120) || "Unnamed project";
+}
 
 export function buildEmailText(params: SubmissionEmailParams): string {
   const lines = [
@@ -72,7 +75,7 @@ export async function sendSubmissionNotification(params: SubmissionEmailParams):
   const body = {
     from: `Article6 <${fromAddress}>`,
     to: [adminEmail],
-    subject: `New Article6 submission — ${params.projectName} — ${params.submissionReference}`,
+    subject: `New Article6 submission — ${normalizeEmailSubjectProject(params.projectName)} — ${params.submissionReference}`,
     text: buildEmailText(params),
     html: buildEmailHtml(params),
   };
@@ -81,7 +84,7 @@ export async function sendSubmissionNotification(params: SubmissionEmailParams):
     console.info("[email] Sending Resend notification", {
       from: `Article6 <${fromAddress}>`,
       to: adminEmail,
-      subject: `New Article6 submission — ${params.projectName} — ${params.submissionReference}`,
+      subject: `New Article6 submission — ${normalizeEmailSubjectProject(params.projectName)} — ${params.submissionReference}`,
     });
 
     const response = await fetch("https://api.resend.com/emails", {

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -10,11 +10,18 @@ interface SubmissionEmailParams {
   timestamp: string;
   submissionSource: string;
   externalContact?: string;
+  submissionReference: string;
+  fileSize: number;
 }
+
+const escapeHtml = (value: string): string => value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+const optional = (value?: string): string => value?.trim() || "Not provided";
+const formatFileSize = (bytes: number): string => `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+const formatTimestamp = (timestamp: string): string => new Intl.DateTimeFormat("en", { dateStyle: "medium", timeStyle: "short", timeZone: "UTC" }).format(new Date(timestamp)) + " UTC";
 
 export function buildEmailText(params: SubmissionEmailParams): string {
   const lines = [
-    "New evidence readiness assessment request.",
+    "New Article6 document submission",
     "",
     "Contact:",
     "",
@@ -24,18 +31,31 @@ export function buildEmailText(params: SubmissionEmailParams): string {
     `Project:       ${params.projectName}`,
     `Methodology:   ${params.methodology}`,
     `Source:        ${params.submissionSource}`,
-    `Reference ID:  ${params.submissionId}`,
-    `File:          ${params.fileName}`,
-    `Submitted:     ${params.timestamp}`,
+    `Reference:     ${params.submissionReference}`,
+    `Document:      ${params.fileName}`,
+    `File size:     ${formatFileSize(params.fileSize)}`,
+    `Submitted:     ${formatTimestamp(params.timestamp)}`,
   ];
 
-  if (params.externalContact) lines.push(`External contact: ${params.externalContact}`);
+  lines.splice(8, 0, `External contact: ${params.externalContact || "Not provided"}`);
 
   if (params.note) {
     lines.push("", `Additional note: ${params.note}`);
   }
 
   return lines.join("\n");
+}
+
+export function buildEmailHtml(params: SubmissionEmailParams): string {
+  const rows: Array<[string, string]> = [
+    ["Reference", params.submissionReference], ["Project", params.projectName], ["Organization", params.organization],
+    ["Contact", params.contactName], ["Work email", optional(params.workEmail)], ["External contact", optional(params.externalContact)],
+    ["Source", params.submissionSource], ["Methodology", params.methodology], ["Document", params.fileName],
+    ["File size", formatFileSize(params.fileSize)], ["Submitted", formatTimestamp(params.timestamp)],
+  ];
+  const table = rows.map(([label, value]) => `<tr><td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;color:#6b7280;font-weight:600;vertical-align:top;white-space:nowrap;">${escapeHtml(label)}</td><td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;color:#111827;word-break:break-word;">${escapeHtml(value)}</td></tr>`).join("");
+  const notes = params.note?.trim() ? `<h2 style="font-size:16px;color:#111827;margin:24px 0 8px;">Notes</h2><div style="padding:12px;background:#f3f4f6;color:#374151;white-space:pre-wrap;">${escapeHtml(params.note)}</div>` : "";
+  return `<!doctype html><html><body style="margin:0;background:#f9fafb;font-family:Arial,Helvetica,sans-serif;color:#111827;"><div style="max-width:640px;margin:0 auto;padding:24px 16px;"><div style="background:#ffffff;border:1px solid #e5e7eb;border-radius:8px;padding:24px;"><h1 style="font-size:20px;margin:0 0 20px;color:#14532d;">New Article6 document submission</h1><table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;font-size:14px;">${table}</table>${notes}</div></div></body></html>`;
 }
 
 export async function sendSubmissionNotification(params: SubmissionEmailParams): Promise<boolean> {
@@ -52,15 +72,16 @@ export async function sendSubmissionNotification(params: SubmissionEmailParams):
   const body = {
     from: `Article6 <${fromAddress}>`,
     to: [adminEmail],
-    subject: "New Article6 PDD submission received",
+    subject: `New Article6 submission — ${params.projectName} — ${params.submissionReference}`,
     text: buildEmailText(params),
+    html: buildEmailHtml(params),
   };
 
   try {
     console.info("[email] Sending Resend notification", {
       from: `Article6 <${fromAddress}>`,
       to: adminEmail,
-      subject: "New Article6 PDD submission received",
+      subject: `New Article6 submission — ${params.projectName} — ${params.submissionReference}`,
     });
 
     const response = await fetch("https://api.resend.com/emails", {

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomUUID, timingSafeEqual } from "crypto";
-import { S3Client, PutObjectCommand, HeadObjectCommand, PutBucketCorsCommand } from "@aws-sdk/client-s3";
+import { S3Client, PutObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { isApprovedSubmissionKey, isSubmissionReference } from "./submissions.ts";
 import { generateSubmissionReference } from "./submission-reference.ts";
@@ -72,32 +72,6 @@ function generateKey(): string {
   const dd = String(now.getDate()).padStart(2, "0");
   const uuid = randomUUID();
   return `submissions/${yyyy}-${mm}-${dd}/${uuid}.pdf`;
-}
-
-export async function configureBucketCors(): Promise<void> {
-  const s3 = getS3Client();
-  const { bucketName } = getR2Credentials();
-
-  console.info("[r2] Configuring CORS for bucket", { bucket: bucketName });
-
-  const command = new PutBucketCorsCommand({
-    Bucket: bucketName,
-    CORSConfiguration: {
-      CORSRules: [
-        {
-          AllowedOrigins: ["*"],
-          AllowedMethods: ["PUT"],
-          AllowedHeaders: ["Content-Type"],
-          ExposeHeaders: ["ETag"],
-          MaxAgeSeconds: 3600,
-        },
-      ],
-    },
-  });
-
-  await s3.send(command);
-
-  console.info("[r2] CORS configuration applied", { bucket: bucketName });
 }
 
 export async function generatePresignedUploadUrl(): Promise<{ uploadUrl: string; uploadReference: string; submissionReference: string }> {

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -1,7 +1,8 @@
 import { createHmac, randomUUID, timingSafeEqual } from "crypto";
 import { S3Client, PutObjectCommand, HeadObjectCommand, PutBucketCorsCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { buildContentDisposition, generateSubmissionReference, sanitizeOriginalFilename, type SubmissionMetadata } from "./submissions.ts";
+import { isApprovedSubmissionKey, isSubmissionReference } from "./submissions.ts";
+import { generateSubmissionReference } from "./submission-reference.ts";
 
 const PDF_CONTENT_TYPE = "application/pdf";
 
@@ -20,22 +21,30 @@ function getR2Credentials() {
   return { accountId, accessKeyId, secretAccessKey, bucketName };
 }
 
-function signUploadReference(key: string, expiresAt: number): string {
+export interface ResolvedUploadReference {
+  key: string;
+  submissionReference: string;
+}
+
+function signUploadReference(key: string, submissionReference: string, expiresAt: number): string {
   const secret = getR2Credentials().secretAccessKey;
-  const payload = Buffer.from(JSON.stringify({ key, expiresAt })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ key, submissionReference, expiresAt })).toString("base64url");
   const signature = createHmac("sha256", secret).update(payload).digest("base64url");
   return `${payload}.${signature}`;
 }
 
-export function resolveUploadReference(reference: unknown): string | null {
+export function resolveUploadReference(reference: unknown): ResolvedUploadReference | null {
   if (typeof reference !== "string") return null;
-  const [payload, signature] = reference.split(".");
+  const parts = reference.split(".");
+  if (parts.length !== 2) return null;
+  const [payload, signature] = parts;
   if (!payload || !signature) return null;
   const expected = createHmac("sha256", getR2Credentials().secretAccessKey).update(payload).digest("base64url");
-  if (signature.length !== expected.length || !timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) return null;
+  if (!/^[A-Za-z0-9_-]+$/.test(signature) || signature.length !== expected.length || !timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) return null;
   try {
-    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { key?: unknown; expiresAt?: unknown };
-    return typeof parsed.key === "string" && typeof parsed.expiresAt === "number" && parsed.expiresAt > Date.now() && /^submissions\/\d{4}-\d{2}-\d{2}\/[0-9a-f-]{36}\.pdf$/.test(parsed.key) ? parsed.key : null;
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { key?: unknown; submissionReference?: unknown; expiresAt?: unknown };
+    if (!isApprovedSubmissionKey(parsed.key) || !isSubmissionReference(parsed.submissionReference) || typeof parsed.expiresAt !== "number" || parsed.expiresAt <= Date.now()) return null;
+    return { key: parsed.key, submissionReference: parsed.submissionReference };
   } catch {
     return null;
   }
@@ -78,7 +87,7 @@ export async function configureBucketCors(): Promise<void> {
         {
           AllowedOrigins: ["*"],
           AllowedMethods: ["PUT"],
-          AllowedHeaders: ["Content-Type", "Content-Disposition", "x-amz-meta-*"],
+          AllowedHeaders: ["Content-Type"],
           ExposeHeaders: ["ETag"],
           MaxAgeSeconds: 3600,
         },
@@ -91,38 +100,12 @@ export async function configureBucketCors(): Promise<void> {
   console.info("[r2] CORS configuration applied", { bucket: bucketName });
 }
 
-export async function generatePresignedUploadUrl(metadata: SubmissionMetadata = {
-  contactName: "",
-  organization: "",
-  projectName: "",
-  methodology: "",
-  submissionSource: "internal",
-  fileName: "document.pdf",
-  fileSize: 1,
-}): Promise<{ uploadUrl: string; uploadReference: string; submissionReference: string; uploadHeaders: Record<string, string> }> {
+export async function generatePresignedUploadUrl(): Promise<{ uploadUrl: string; uploadReference: string; submissionReference: string }> {
   const s3 = getS3Client();
   const { bucketName } = getR2Credentials();
   const key = generateKey();
   const submissionReference = generateSubmissionReference();
   const expiresAt = Date.now() + 10 * 60 * 1000;
-  const submissionTimestamp = new Date().toISOString();
-  const metadataValue = (value: string): string => value.replace(/[\u0000-\u001f\u007f]/g, " ").slice(0, 512);
-  const originalFilename = sanitizeOriginalFilename(metadata.fileName);
-  const uploadHeaders = {
-    "Content-Type": PDF_CONTENT_TYPE,
-    "Content-Disposition": buildContentDisposition(metadata.fileName),
-    "x-amz-meta-original-filename": originalFilename,
-    "x-amz-meta-project-name": metadataValue(metadata.projectName),
-    "x-amz-meta-organization": metadataValue(metadata.organization),
-    "x-amz-meta-contact-name": metadataValue(metadata.contactName),
-    ...(metadata.workEmail ? { "x-amz-meta-work-email": metadataValue(metadata.workEmail) } : {}),
-    ...(metadata.externalContact ? { "x-amz-meta-external-contact": metadataValue(metadata.externalContact) } : {}),
-    "x-amz-meta-submission-source": metadata.submissionSource,
-    "x-amz-meta-methodology": metadataValue(metadata.methodology),
-    "x-amz-meta-file-size": String(metadata.fileSize),
-    "x-amz-meta-submission-timestamp": submissionTimestamp,
-    "x-amz-meta-submission-reference": submissionReference,
-  };
 
   console.info("[r2] Generating presigned PUT URL", { bucket: bucketName, key });
 
@@ -130,20 +113,6 @@ export async function generatePresignedUploadUrl(metadata: SubmissionMetadata = 
     Bucket: bucketName,
     Key: key,
     ContentType: PDF_CONTENT_TYPE,
-    ContentDisposition: uploadHeaders["Content-Disposition"],
-    Metadata: {
-      "original-filename": originalFilename,
-      "project-name": metadataValue(metadata.projectName),
-      organization: metadataValue(metadata.organization),
-      "contact-name": metadataValue(metadata.contactName),
-      ...(metadata.workEmail ? { "work-email": metadataValue(metadata.workEmail) } : {}),
-      ...(metadata.externalContact ? { "external-contact": metadataValue(metadata.externalContact) } : {}),
-      "submission-source": metadata.submissionSource,
-      methodology: metadataValue(metadata.methodology),
-      "file-size": String(metadata.fileSize),
-      "submission-timestamp": submissionTimestamp,
-      "submission-reference": submissionReference,
-    },
   });
 
   const uploadUrl = await getSignedUrl(s3, command, {
@@ -152,7 +121,7 @@ export async function generatePresignedUploadUrl(metadata: SubmissionMetadata = 
 
   console.info("[r2] Presigned URL generated", { key, expiresIn: 600 });
 
-  return { uploadUrl, uploadReference: signUploadReference(key, expiresAt), submissionReference, uploadHeaders };
+  return { uploadUrl, uploadReference: signUploadReference(key, submissionReference, expiresAt), submissionReference };
 }
 
 export interface ObjectVerificationResult {

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -1,6 +1,7 @@
-import { randomUUID } from "crypto";
+import { createHmac, randomUUID, timingSafeEqual } from "crypto";
 import { S3Client, PutObjectCommand, HeadObjectCommand, PutBucketCorsCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { buildContentDisposition, generateSubmissionReference, sanitizeOriginalFilename, type SubmissionMetadata } from "./submissions.ts";
 
 const PDF_CONTENT_TYPE = "application/pdf";
 
@@ -17,6 +18,27 @@ function getR2Credentials() {
   }
 
   return { accountId, accessKeyId, secretAccessKey, bucketName };
+}
+
+function signUploadReference(key: string, expiresAt: number): string {
+  const secret = getR2Credentials().secretAccessKey;
+  const payload = Buffer.from(JSON.stringify({ key, expiresAt })).toString("base64url");
+  const signature = createHmac("sha256", secret).update(payload).digest("base64url");
+  return `${payload}.${signature}`;
+}
+
+export function resolveUploadReference(reference: unknown): string | null {
+  if (typeof reference !== "string") return null;
+  const [payload, signature] = reference.split(".");
+  if (!payload || !signature) return null;
+  const expected = createHmac("sha256", getR2Credentials().secretAccessKey).update(payload).digest("base64url");
+  if (signature.length !== expected.length || !timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { key?: unknown; expiresAt?: unknown };
+    return typeof parsed.key === "string" && typeof parsed.expiresAt === "number" && parsed.expiresAt > Date.now() && /^submissions\/\d{4}-\d{2}-\d{2}\/[0-9a-f-]{36}\.pdf$/.test(parsed.key) ? parsed.key : null;
+  } catch {
+    return null;
+  }
 }
 
 function getS3Client(): S3Client {
@@ -56,7 +78,7 @@ export async function configureBucketCors(): Promise<void> {
         {
           AllowedOrigins: ["*"],
           AllowedMethods: ["PUT"],
-          AllowedHeaders: ["Content-Type"],
+          AllowedHeaders: ["Content-Type", "Content-Disposition", "x-amz-meta-*"],
           ExposeHeaders: ["ETag"],
           MaxAgeSeconds: 3600,
         },
@@ -69,10 +91,38 @@ export async function configureBucketCors(): Promise<void> {
   console.info("[r2] CORS configuration applied", { bucket: bucketName });
 }
 
-export async function generatePresignedUploadUrl(): Promise<{ uploadUrl: string; key: string }> {
+export async function generatePresignedUploadUrl(metadata: SubmissionMetadata = {
+  contactName: "",
+  organization: "",
+  projectName: "",
+  methodology: "",
+  submissionSource: "internal",
+  fileName: "document.pdf",
+  fileSize: 1,
+}): Promise<{ uploadUrl: string; uploadReference: string; submissionReference: string; uploadHeaders: Record<string, string> }> {
   const s3 = getS3Client();
   const { bucketName } = getR2Credentials();
   const key = generateKey();
+  const submissionReference = generateSubmissionReference();
+  const expiresAt = Date.now() + 10 * 60 * 1000;
+  const submissionTimestamp = new Date().toISOString();
+  const metadataValue = (value: string): string => value.replace(/[\u0000-\u001f\u007f]/g, " ").slice(0, 512);
+  const originalFilename = sanitizeOriginalFilename(metadata.fileName);
+  const uploadHeaders = {
+    "Content-Type": PDF_CONTENT_TYPE,
+    "Content-Disposition": buildContentDisposition(metadata.fileName),
+    "x-amz-meta-original-filename": originalFilename,
+    "x-amz-meta-project-name": metadataValue(metadata.projectName),
+    "x-amz-meta-organization": metadataValue(metadata.organization),
+    "x-amz-meta-contact-name": metadataValue(metadata.contactName),
+    ...(metadata.workEmail ? { "x-amz-meta-work-email": metadataValue(metadata.workEmail) } : {}),
+    ...(metadata.externalContact ? { "x-amz-meta-external-contact": metadataValue(metadata.externalContact) } : {}),
+    "x-amz-meta-submission-source": metadata.submissionSource,
+    "x-amz-meta-methodology": metadataValue(metadata.methodology),
+    "x-amz-meta-file-size": String(metadata.fileSize),
+    "x-amz-meta-submission-timestamp": submissionTimestamp,
+    "x-amz-meta-submission-reference": submissionReference,
+  };
 
   console.info("[r2] Generating presigned PUT URL", { bucket: bucketName, key });
 
@@ -80,6 +130,20 @@ export async function generatePresignedUploadUrl(): Promise<{ uploadUrl: string;
     Bucket: bucketName,
     Key: key,
     ContentType: PDF_CONTENT_TYPE,
+    ContentDisposition: uploadHeaders["Content-Disposition"],
+    Metadata: {
+      "original-filename": originalFilename,
+      "project-name": metadataValue(metadata.projectName),
+      organization: metadataValue(metadata.organization),
+      "contact-name": metadataValue(metadata.contactName),
+      ...(metadata.workEmail ? { "work-email": metadataValue(metadata.workEmail) } : {}),
+      ...(metadata.externalContact ? { "external-contact": metadataValue(metadata.externalContact) } : {}),
+      "submission-source": metadata.submissionSource,
+      methodology: metadataValue(metadata.methodology),
+      "file-size": String(metadata.fileSize),
+      "submission-timestamp": submissionTimestamp,
+      "submission-reference": submissionReference,
+    },
   });
 
   const uploadUrl = await getSignedUrl(s3, command, {
@@ -88,7 +152,7 @@ export async function generatePresignedUploadUrl(): Promise<{ uploadUrl: string;
 
   console.info("[r2] Presigned URL generated", { key, expiresIn: 600 });
 
-  return { uploadUrl, key };
+  return { uploadUrl, uploadReference: signUploadReference(key, expiresAt), submissionReference, uploadHeaders };
 }
 
 export interface ObjectVerificationResult {

--- a/lib/submission-reference.ts
+++ b/lib/submission-reference.ts
@@ -1,0 +1,10 @@
+import { randomBytes } from "crypto";
+
+const REFERENCE_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+export function generateSubmissionReference(now = new Date()): string {
+  const date = `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, "0")}${String(now.getUTCDate()).padStart(2, "0")}`;
+  const bytes = randomBytes(6);
+  const suffix = Array.from(bytes, (value) => REFERENCE_ALPHABET[value % REFERENCE_ALPHABET.length]).join("");
+  return `A6-${date}-${suffix}`;
+}

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -20,6 +20,37 @@ export const NON_WEBSITE_SOURCES: SubmissionSource[] = ["whatsapp", "email", "in
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+export function sanitizeOriginalFilename(fileName: string): string {
+  const baseName = fileName.replace(/\\/g, "/").split("/").pop() || "document.pdf";
+  const sanitized = baseName
+    .normalize("NFKC")
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .replace(/["']/g, "")
+    .replace(/[^a-zA-Z0-9._()\- ]/g, "_")
+    .replace(/^\.+/, "")
+    .trim()
+    .slice(0, 180);
+  return sanitized || "document.pdf";
+}
+
+export function buildContentDisposition(fileName: string): string {
+  return `attachment; filename="${sanitizeOriginalFilename(fileName)}"`;
+}
+
+export function generateSubmissionReference(now = new Date()): string {
+  const date = `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, "0")}${String(now.getUTCDate()).padStart(2, "0")}`;
+  const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+  const randomValues = new Uint32Array(6);
+  if (globalThis.crypto?.getRandomValues) globalThis.crypto.getRandomValues(randomValues);
+  else randomValues.forEach((_, index) => { randomValues[index] = Math.floor(Math.random() * 0xffffffff); });
+  const suffix = Array.from(randomValues, (value) => alphabet[value % alphabet.length]).join("");
+  return `A6-${date}-${suffix}`;
+}
+
+export function isSubmissionReference(value: unknown): value is string {
+  return typeof value === "string" && /^A6-\d{8}-[0-9A-HJKMNP-TV-Z]{6}$/.test(value);
+}
+
 export function validateSubmissionMetadata(
   input: Partial<SubmissionMetadata> & { submissionSource?: unknown }
 ): string | null {

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -37,16 +37,6 @@ export function buildContentDisposition(fileName: string): string {
   return `attachment; filename="${sanitizeOriginalFilename(fileName)}"`;
 }
 
-export function generateSubmissionReference(now = new Date()): string {
-  const date = `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, "0")}${String(now.getUTCDate()).padStart(2, "0")}`;
-  const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-  const randomValues = new Uint32Array(6);
-  if (globalThis.crypto?.getRandomValues) globalThis.crypto.getRandomValues(randomValues);
-  else randomValues.forEach((_, index) => { randomValues[index] = Math.floor(Math.random() * 0xffffffff); });
-  const suffix = Array.from(randomValues, (value) => alphabet[value % alphabet.length]).join("");
-  return `A6-${date}-${suffix}`;
-}
-
 export function isSubmissionReference(value: unknown): value is string {
   return typeof value === "string" && /^A6-\d{8}-[0-9A-HJKMNP-TV-Z]{6}$/.test(value);
 }
@@ -101,7 +91,7 @@ export function isPdfUpload(file: { type: string; size: number }): string | null
   return null;
 }
 
-export function isApprovedSubmissionKey(key: unknown): boolean {
+export function isApprovedSubmissionKey(key: unknown): key is string {
   return typeof key === "string" && /^submissions\/\d{4}-\d{2}-\d{2}\/[0-9a-f-]{36}\.pdf$/.test(key);
 }
 
@@ -113,6 +103,6 @@ export function validateStoredObject(
   if (object.size <= 0) return "Uploaded file is empty.";
   if (object.size > MAX_FILE_SIZE) return "Uploaded file exceeds the 50MB limit.";
   if (object.size !== declaredSize) return "Uploaded file size does not match the declared file size.";
-  if (object.contentType && object.contentType !== PDF_CONTENT_TYPE) return "Uploaded file is not a valid PDF.";
+  if (object.contentType !== PDF_CONTENT_TYPE) return "Uploaded file is not a valid PDF.";
   return null;
 }

--- a/pages/api/upload/confirm.ts
+++ b/pages/api/upload/confirm.ts
@@ -1,12 +1,12 @@
-import { randomUUID } from "crypto";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { getBucketName, verifyObjectExists } from "../../../lib/r2";
+import { getBucketName, resolveUploadReference, verifyObjectExists } from "../../../lib/r2";
 import { sendSubmissionNotification } from "../../../lib/email";
 import { hasInternalUploadSession } from "../../../lib/internal-auth";
-import { isApprovedSubmissionKey, validateStoredObject, validateSubmissionMetadata, type SubmissionSource } from "../../../lib/submissions";
+import { isSubmissionReference, validateStoredObject, validateSubmissionMetadata, type SubmissionSource } from "../../../lib/submissions";
 
 interface ConfirmRequestBody {
-  key: string;
+  uploadReference: string;
+  submissionReference: string;
   fileName: string;
   fileSize: number;
   contactName: string;
@@ -20,9 +20,7 @@ interface ConfirmRequestBody {
 }
 
 export function validateConfirmRequest(body: Partial<ConfirmRequestBody>): string | null {
-  if (!isApprovedSubmissionKey(body.key)) {
-    return "Invalid upload key prefix.";
-  }
+  if (!body.uploadReference || !body.submissionReference || !isSubmissionReference(body.submissionReference)) return "Invalid upload reference.";
   return validateSubmissionMetadata(body);
 }
 
@@ -41,16 +39,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const verification = await verifyObjectExists(body.key as string);
+    const key = resolveUploadReference(body.uploadReference);
+    if (!key) return res.status(400).json({ error: "Invalid or expired upload reference." });
+    const verification = await verifyObjectExists(key);
     const storedObjectError = validateStoredObject(verification, body.fileSize!);
     if (storedObjectError) return res.status(400).json({ error: storedObjectError });
 
-    const submissionId = randomUUID();
+    const submissionId = body.submissionReference!;
     const timestamp = new Date().toISOString();
     const submission = {
       id: submissionId,
       timestamp,
-      key: body.key,
+      key,
       bucket: getBucketName(),
       fileName: body.fileName!.trim(),
       fileSize: verification.size,
@@ -76,12 +76,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       note: submission.note,
       fileName: submission.fileName,
       submissionId: submission.id,
+      submissionReference: body.submissionReference!,
+      fileSize: submission.fileSize,
       timestamp: submission.timestamp,
     });
 
     return res.status(200).json({
       success: true,
-      submissionId,
+      submissionId: body.submissionReference,
       message: body.submissionSource === "website" ? "Your PDD has been submitted for scope review. We will respond within two business days." : "Internal PDD submission received.",
     });
   } catch (err) {

--- a/pages/api/upload/confirm.ts
+++ b/pages/api/upload/confirm.ts
@@ -2,11 +2,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getBucketName, resolveUploadReference, verifyObjectExists } from "../../../lib/r2";
 import { sendSubmissionNotification } from "../../../lib/email";
 import { hasInternalUploadSession } from "../../../lib/internal-auth";
-import { isSubmissionReference, validateStoredObject, validateSubmissionMetadata, type SubmissionSource } from "../../../lib/submissions";
+import { sanitizeOriginalFilename, validateStoredObject, validateSubmissionMetadata, type SubmissionSource } from "../../../lib/submissions";
 
 interface ConfirmRequestBody {
   uploadReference: string;
-  submissionReference: string;
   fileName: string;
   fileSize: number;
   contactName: string;
@@ -20,7 +19,7 @@ interface ConfirmRequestBody {
 }
 
 export function validateConfirmRequest(body: Partial<ConfirmRequestBody>): string | null {
-  if (!body.uploadReference || !body.submissionReference || !isSubmissionReference(body.submissionReference)) return "Invalid upload reference.";
+  if (!body.uploadReference) return "Invalid upload reference.";
   return validateSubmissionMetadata(body);
 }
 
@@ -39,20 +38,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const key = resolveUploadReference(body.uploadReference);
-    if (!key) return res.status(400).json({ error: "Invalid or expired upload reference." });
-    const verification = await verifyObjectExists(key);
+    const resolved = resolveUploadReference(body.uploadReference);
+    if (!resolved) return res.status(400).json({ error: "Invalid or expired upload reference." });
+    const verification = await verifyObjectExists(resolved.key);
     const storedObjectError = validateStoredObject(verification, body.fileSize!);
     if (storedObjectError) return res.status(400).json({ error: storedObjectError });
-
-    const submissionId = body.submissionReference!;
+    const submissionId = resolved.submissionReference;
     const timestamp = new Date().toISOString();
     const submission = {
       id: submissionId,
       timestamp,
-      key,
+      key: resolved.key,
       bucket: getBucketName(),
-      fileName: body.fileName!.trim(),
+      fileName: sanitizeOriginalFilename(body.fileName!),
       fileSize: verification.size,
       contactName: body.contactName!.trim(),
       workEmail: body.workEmail?.trim().toLowerCase() || undefined,
@@ -76,14 +74,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       note: submission.note,
       fileName: submission.fileName,
       submissionId: submission.id,
-      submissionReference: body.submissionReference!,
+      submissionReference: resolved.submissionReference,
       fileSize: submission.fileSize,
       timestamp: submission.timestamp,
     });
 
     return res.status(200).json({
       success: true,
-      submissionId: body.submissionReference,
+      submissionId: resolved.submissionReference,
       message: body.submissionSource === "website" ? "Your PDD has been submitted for scope review. We will respond within two business days." : "Internal PDD submission received.",
     });
   } catch (err) {

--- a/pages/api/upload/presign.ts
+++ b/pages/api/upload/presign.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { configureBucketCors, generatePresignedUploadUrl } from "../../../lib/r2";
+import { generatePresignedUploadUrl } from "../../../lib/r2";
 import { hasInternalUploadSession } from "../../../lib/internal-auth";
 import { PDF_CONTENT_TYPE, validateSubmissionMetadata, type SubmissionSource } from "../../../lib/submissions";
 
@@ -38,12 +38,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    try {
-      await configureBucketCors();
-    } catch (corsErr) {
-      console.warn("[presign] CORS configuration skipped:", corsErr instanceof Error ? corsErr.message : String(corsErr));
-    }
-
     const { uploadUrl, uploadReference } = await generatePresignedUploadUrl();
     return res.status(200).json({ uploadUrl, uploadReference, expiresIn: 600 });
   } catch (err) {

--- a/pages/api/upload/presign.ts
+++ b/pages/api/upload/presign.ts
@@ -44,8 +44,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       console.warn("[presign] CORS configuration skipped:", corsErr instanceof Error ? corsErr.message : String(corsErr));
     }
 
-    const { uploadUrl, key } = await generatePresignedUploadUrl();
-    return res.status(200).json({ uploadUrl, key, expiresIn: 600 });
+    const { uploadUrl, uploadReference, submissionReference, uploadHeaders } = await generatePresignedUploadUrl(body as PresignRequestBody);
+    return res.status(200).json({ uploadUrl, uploadReference, submissionReference, uploadHeaders, expiresIn: 600 });
   } catch (err) {
     console.error("[presign] Error generating upload URL:", err instanceof Error ? err.message : String(err));
     return res.status(500).json({ error: "Failed to generate upload URL. Please try again later." });

--- a/pages/api/upload/presign.ts
+++ b/pages/api/upload/presign.ts
@@ -44,8 +44,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       console.warn("[presign] CORS configuration skipped:", corsErr instanceof Error ? corsErr.message : String(corsErr));
     }
 
-    const { uploadUrl, uploadReference, submissionReference, uploadHeaders } = await generatePresignedUploadUrl(body as PresignRequestBody);
-    return res.status(200).json({ uploadUrl, uploadReference, submissionReference, uploadHeaders, expiresIn: 600 });
+    const { uploadUrl, uploadReference } = await generatePresignedUploadUrl();
+    return res.status(200).json({ uploadUrl, uploadReference, expiresIn: 600 });
   } catch (err) {
     console.error("[presign] Error generating upload URL:", err instanceof Error ? err.message : String(err));
     return res.status(500).json({ error: "Failed to generate upload URL. Please try again later." });

--- a/tests/submissions.test.ts
+++ b/tests/submissions.test.ts
@@ -140,10 +140,11 @@ test("presigned browser PUT URLs do not include automatic checksum parameters", 
 test("browser upload keeps the existing Content-Type-only CORS contract", () => {
   const form = fs.readFileSync(new URL("../components/preview/PddUploadForm.tsx", import.meta.url), "utf8");
   const r2 = fs.readFileSync(new URL("../lib/r2.ts", import.meta.url), "utf8");
+  const presign = fs.readFileSync(new URL("../pages/api/upload/presign.ts", import.meta.url), "utf8");
   assert.match(form, /headers:\s*\{\s*'Content-Type': 'application\/pdf'\s*\}/);
   assert.doesNotMatch(form, /uploadHeaders|x-amz-meta-|Content-Disposition/);
-  assert.match(r2, /AllowedHeaders: \["Content-Type"\]/);
-  assert.doesNotMatch(r2, /AllowedHeaders: \[[^\]]*(x-amz-meta|Content-Disposition)/);
+  assert.doesNotMatch(r2, /PutBucketCorsCommand|configureBucketCors|AllowedHeaders/);
+  assert.doesNotMatch(presign, /PutBucketCorsCommand|configureBucketCors|CORS/);
 });
 
 test("email subject project normalization removes controls and limits length", () => {

--- a/tests/submissions.test.ts
+++ b/tests/submissions.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
-import { buildEmailText } from "../lib/email.ts";
+import { buildEmailHtml, buildEmailText } from "../lib/email.ts";
 import { generatePresignedUploadUrl } from "../lib/r2.ts";
 import { getAppLayoutKind } from "../lib/layout.ts";
 import {
@@ -10,6 +10,9 @@ import {
   MAX_FILE_SIZE,
   validateStoredObject,
   validateSubmissionMetadata,
+  buildContentDisposition,
+  generateSubmissionReference,
+  sanitizeOriginalFilename,
 } from "../lib/submissions.ts";
 
 const base = {
@@ -51,6 +54,18 @@ test("only opaque submission keys are approved", () => {
   assert.equal(isApprovedSubmissionKey("submissions/2026-08-01/123e4567-e89b-12d3-a456-426614174000-client.pdf"), false);
 });
 
+test("submission references are readable and independent of the R2 key", () => {
+  const reference = generateSubmissionReference(new Date("2026-08-02T12:00:00Z"));
+  assert.match(reference, /^A6-20260802-[0-9A-HJKMNP-TV-Z]{6}$/);
+  assert.doesNotMatch(reference, /Synthetic|client|email/i);
+});
+
+test("original filenames are sanitized for safe download headers", () => {
+  const safe = sanitizeOriginalFilename('../client name\"\r\n.pdf');
+  assert.equal(safe, "client name.pdf");
+  assert.equal(buildContentDisposition('../client name\"\r\n.pdf'), 'attachment; filename="client name.pdf"');
+});
+
 test("confirmation rejects missing, mismatched, oversized, and non-PDF objects", () => {
   assert.match(validateStoredObject({ exists: false, size: 0 }, 1) || "", /not found/i);
   assert.match(validateStoredObject({ exists: true, size: 100 }, 99) || "", /match/i);
@@ -67,11 +82,27 @@ test("internal notification text works without workEmail and identifies source",
     note: "",
     fileName: "synthetic.pdf",
     submissionId: "synthetic-reference",
+    submissionReference: "A6-20260801-ABC123",
+    fileSize: 51329000,
     timestamp: "2026-08-01T00:00:00.000Z",
     submissionSource: "whatsapp",
   });
   assert.match(text, /Source:\s+whatsapp/);
   assert.match(text, /Email:\s+Not provided/);
+});
+
+test("internal notification HTML has escaped fields, optional values, and no R2 URL", () => {
+  const html = buildEmailHtml({
+    contactName: '<img src=x onerror="bad">', organization: "Synthetic Organization", projectName: "Synthetic Project",
+    methodology: "Synthetic Methodology", note: "<script>alert(1)</script>", fileName: "client.pdf", submissionId: "id",
+    submissionReference: "A6-20260801-ABC123", fileSize: 51329000, timestamp: "2026-08-01T00:00:00.000Z", submissionSource: "internal",
+  });
+  assert.match(html, /New Article6 document submission/);
+  assert.match(html, /Reference/);
+  assert.match(html, /External contact/);
+  assert.match(html, /Not provided/);
+  assert.match(html, /&lt;img/);
+  assert.doesNotMatch(html, /<img|<script|r2\.cloudflarestorage\.com/);
 });
 
 test("presigned browser PUT URLs do not include automatic checksum parameters", async () => {
@@ -80,10 +111,13 @@ test("presigned browser PUT URLs do not include automatic checksum parameters", 
   process.env.R2_SECRET_ACCESS_KEY = "synthetic-secret-key";
   process.env.R2_BUCKET_NAME = "synthetic-private-bucket";
 
-  const { uploadUrl } = await generatePresignedUploadUrl();
+  const result = await generatePresignedUploadUrl();
+  const { uploadUrl } = result;
   const query = new URL(uploadUrl).searchParams;
   assert.equal(query.has("x-amz-checksum-crc32"), false);
   assert.equal(query.has("x-amz-sdk-checksum-algorithm"), false);
+  assert.equal("key" in result, false);
+  assert.match(result.uploadHeaders["Content-Disposition"], /^attachment; filename="[^"]+"$/);
 });
 
 test("public pages use marketing chrome and internal pages do not", () => {

--- a/tests/submissions.test.ts
+++ b/tests/submissions.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import fs from "node:fs";
 import test from "node:test";
-import { buildEmailHtml, buildEmailText } from "../lib/email.ts";
-import { generatePresignedUploadUrl } from "../lib/r2.ts";
+import { buildEmailHtml, buildEmailText, normalizeEmailSubjectProject } from "../lib/email.ts";
+import { generatePresignedUploadUrl, resolveUploadReference } from "../lib/r2.ts";
+import { generateSubmissionReference } from "../lib/submission-reference.ts";
 import { getAppLayoutKind } from "../lib/layout.ts";
 import {
   isApprovedSubmissionKey,
@@ -11,7 +13,6 @@ import {
   validateStoredObject,
   validateSubmissionMetadata,
   buildContentDisposition,
-  generateSubmissionReference,
   sanitizeOriginalFilename,
 } from "../lib/submissions.ts";
 
@@ -71,6 +72,13 @@ test("confirmation rejects missing, mismatched, oversized, and non-PDF objects",
   assert.match(validateStoredObject({ exists: true, size: 100 }, 99) || "", /match/i);
   assert.match(validateStoredObject({ exists: true, size: MAX_FILE_SIZE + 1 }, MAX_FILE_SIZE + 1) || "", /50MB/i);
   assert.match(validateStoredObject({ exists: true, size: 100, contentType: "text/plain" }, 100) || "", /PDF/i);
+  assert.match(validateStoredObject({ exists: true, size: 100 }, 100) || "", /PDF/i);
+});
+
+test("confirmation derives the reference and gates notification on upload verification", () => {
+  const confirm = fs.readFileSync(new URL("../pages/api/upload/confirm.ts", import.meta.url), "utf8");
+  assert.doesNotMatch(confirm, /submissionReference:\s*string/);
+  assert.ok(confirm.indexOf("if (storedObjectError)") < confirm.indexOf("await sendSubmissionNotification"));
 });
 
 test("internal notification text works without workEmail and identifies source", () => {
@@ -117,7 +125,32 @@ test("presigned browser PUT URLs do not include automatic checksum parameters", 
   assert.equal(query.has("x-amz-checksum-crc32"), false);
   assert.equal(query.has("x-amz-sdk-checksum-algorithm"), false);
   assert.equal("key" in result, false);
-  assert.match(result.uploadHeaders["Content-Disposition"], /^attachment; filename="[^"]+"$/);
+  const resolved = resolveUploadReference(result.uploadReference);
+  assert.ok(resolved);
+  assert.equal(resolved.submissionReference, result.submissionReference);
+  assert.match(resolved.key, /^submissions\/\d{4}-\d{2}-\d{2}\/[0-9a-f-]{36}\.pdf$/);
+  const [payload, signature] = result.uploadReference.split(".");
+  const tamperedPayload = Buffer.from(JSON.stringify({ key: resolved.key, submissionReference: "A6-20260802-XYZ789", expiresAt: Date.now() + 600000 })).toString("base64url");
+  assert.equal(resolveUploadReference(`${tamperedPayload}.${signature}`), null);
+  const expiredPayload = Buffer.from(JSON.stringify({ key: resolved.key, submissionReference: resolved.submissionReference, expiresAt: Date.now() - 1 })).toString("base64url");
+  const expiredSignature = createHmac("sha256", process.env.R2_SECRET_ACCESS_KEY!).update(expiredPayload).digest("base64url");
+  assert.equal(resolveUploadReference(`${expiredPayload}.${expiredSignature}`), null);
+});
+
+test("browser upload keeps the existing Content-Type-only CORS contract", () => {
+  const form = fs.readFileSync(new URL("../components/preview/PddUploadForm.tsx", import.meta.url), "utf8");
+  const r2 = fs.readFileSync(new URL("../lib/r2.ts", import.meta.url), "utf8");
+  assert.match(form, /headers:\s*\{\s*'Content-Type': 'application\/pdf'\s*\}/);
+  assert.doesNotMatch(form, /uploadHeaders|x-amz-meta-|Content-Disposition/);
+  assert.match(r2, /AllowedHeaders: \["Content-Type"\]/);
+  assert.doesNotMatch(r2, /AllowedHeaders: \[[^\]]*(x-amz-meta|Content-Disposition)/);
+});
+
+test("email subject project normalization removes controls and limits length", () => {
+  const normalized = normalizeEmailSubjectProject("  Project\n\tName\r\0 " + "x".repeat(200));
+  assert.equal(normalized.length, 120);
+  assert.match(normalized, /^Project Name x+/);
+  assert.doesNotMatch(normalized, /[\u0000-\u001f\u007f]/);
 });
 
 test("public pages use marketing chrome and internal pages do not", () => {


### PR DESCRIPTION
## Summary

- Preserve opaque private R2 object keys while adding a stable human-readable submission reference.
- Cryptographically bind the readable `A6-...` reference to the signed upload reference.
- Replace the rough notification with a Gmail-compatible responsive HTML table and plain-text fallback.

## Details

- Browser uploads directly to private R2 using only `Content-Type: application/pdf` on the presigned PUT.
- Opaque R2 keys remain private; no raw key or permanent R2 URL is included in client confirmation or notification output.
- Expired or tampered upload references are rejected.
- Confirmation verifies object existence, declared size, and PDF content type.
- Notification HTML escapes user-controlled values and normalizes email subjects.
- The notification includes the readable reference, project, organization, contact details, source, methodology, original filename, file size, submission time, and optional notes.
- Public work-email requirements and internal submissions without work email remain intact.
- Existing PDF-only and 50 MiB validation, Preview/Production bucket separation, authentication, confirmation, and form reset behavior are preserved.
- Application request handlers do not mutate bucket CORS.

## Manual verification

- Browser upload to private Preview R2 succeeded.
- Confirmation succeeded.
- Gmail received the formatted HTML table and plain-text fallback.

## Validation

- `npm test -- tests/submissions.test.ts` (15 passing)
- `npx tsc --noEmit`
- `npx eslint lib/submissions.ts lib/r2.ts lib/email.ts pages/api/upload/presign.ts pages/api/upload/confirm.ts components/preview/PddUploadForm.tsx tests/submissions.test.ts`
- `git diff --check`

Not run: `npm run build`, `npm run pr:gate`, or broad end-to-end suites.