### PR TITLE
Add internal submission review queue and PDF downloads

### DIFF
--- a/components/InternalHeader.tsx
+++ b/components/InternalHeader.tsx
@@ -11,6 +11,9 @@ export default function InternalHeader() {
           Article6 Internal
         </Link>
         <div className="flex items-center gap-4 text-sm">
+          <Link href="/internal/submissions" className="text-gray-600 hover:text-gray-900">
+            Submissions
+          </Link>
           <Link href="/internal/submissions/new" onClick={resetInternalPage} className="text-forest-700 hover:text-forest-800">
             New submission
           </Link>

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomUUID, timingSafeEqual } from "crypto";
-import { S3Client, PutObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
+import { S3Client, GetObjectCommand, PutObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { isApprovedSubmissionKey, isSubmissionReference } from "./submissions.ts";
 import { generateSubmissionReference } from "./submission-reference.ts";
@@ -98,6 +98,22 @@ export async function generatePresignedUploadUrl(): Promise<{ uploadUrl: string;
   return { uploadUrl, uploadReference: signUploadReference(key, submissionReference, expiresAt), submissionReference };
 }
 
+export async function generatePresignedDownloadUrl(bucket: string, key: string): Promise<string> {
+  if (!bucket || !isApprovedSubmissionKey(key)) {
+    throw new Error("Invalid stored submission object.");
+  }
+
+  const s3 = getS3Client();
+  const command = new GetObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    ResponseContentType: PDF_CONTENT_TYPE,
+    ResponseContentDisposition: "attachment",
+  });
+
+  return getSignedUrl(s3, command, { expiresIn: 300 });
+}
+
 export interface ObjectVerificationResult {
   exists: boolean;
   size: number;
@@ -105,9 +121,9 @@ export interface ObjectVerificationResult {
   lastModified: Date | undefined;
 }
 
-export async function verifyObjectExists(key: string): Promise<ObjectVerificationResult> {
+export async function verifyObjectExists(key: string, bucket?: string): Promise<ObjectVerificationResult> {
   const s3 = getS3Client();
-  const { bucketName } = getR2Credentials();
+  const bucketName = bucket || getR2Credentials().bucketName;
 
   console.info("[r2] Verifying object existence", { bucket: bucketName, key });
 

--- a/lib/submission-store.ts
+++ b/lib/submission-store.ts
@@ -91,3 +91,8 @@ export async function getSubmissionByReference(reference: string): Promise<Submi
   const result = await getPool().query("SELECT * FROM submissions WHERE reference = $1 LIMIT 1", [reference]);
   return result.rows[0] ? toRecord(result.rows[0]) : null;
 }
+
+export async function getSubmissions(): Promise<SubmissionRecord[]> {
+  const result = await getPool().query("SELECT * FROM submissions ORDER BY created_at DESC");
+  return result.rows.map(toRecord);
+}

--- a/pages/api/internal/submissions/[reference]/download.ts
+++ b/pages/api/internal/submissions/[reference]/download.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { hasInternalUploadSession } from "../../../../../lib/internal-auth";
+import { generatePresignedDownloadUrl, verifyObjectExists } from "../../../../../lib/r2";
+import { getSubmissionByReference } from "../../../../../lib/submission-store";
+import { isSubmissionReference } from "../../../../../lib/submissions";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!(await hasInternalUploadSession(req))) return res.status(401).json({ error: "Authentication required." });
+  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed." });
+
+  const reference = req.query.reference;
+  if (!isSubmissionReference(reference)) return res.status(404).json({ error: "Submission not found." });
+  const submission = await getSubmissionByReference(reference);
+  if (!submission) return res.status(404).json({ error: "Submission not found." });
+  if (!submission.bucket || !submission.objectKey) return res.status(404).json({ error: "Submission PDF is not available." });
+
+  try {
+    const object = await verifyObjectExists(submission.objectKey, submission.bucket);
+    if (!object.exists) return res.status(404).json({ error: "Submission PDF is not available." });
+    return res.redirect(307, await generatePresignedDownloadUrl(submission.bucket, submission.objectKey));
+  } catch (error) {
+    console.error("[submissions] PDF download signing failed", { reference, error });
+    return res.status(502).json({ error: "Unable to prepare the submission PDF for download." });
+  }
+}

--- a/pages/internal/submissions/[reference].tsx
+++ b/pages/internal/submissions/[reference].tsx
@@ -30,7 +30,7 @@ export default function SubmissionDetailPage({ submission }: InferGetServerSideP
         <Detail label="File size" value={`${(submission.fileSize / (1024 * 1024)).toFixed(2)} MiB`} />
         <Detail label="Submitted" value={new Date(submission.createdAt).toLocaleString()} /><Detail label="Status" value={submission.status} />
       </dl><div className="mt-6 border-t border-gray-100 pt-6"><Detail label="Notes" value={submission.notes} /></div>
-      <div className="mt-8 flex flex-wrap gap-3 border-t border-gray-100 pt-6"><button type="button" disabled className="rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-500">Download PDF</button><button type="button" disabled className="rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-500">Run Quick Check</button></div>
+      <div className="mt-8 flex flex-wrap gap-3 border-t border-gray-100 pt-6"><a href={`/api/internal/submissions/${submission.reference}/download`} className="rounded-md bg-forest-700 px-4 py-2 text-sm font-medium text-white hover:bg-forest-800">Download PDF</a><button type="button" disabled className="rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-500">Run Quick Check</button></div>
       </div>
     </div></main>
   </>;

--- a/pages/internal/submissions/index.tsx
+++ b/pages/internal/submissions/index.tsx
@@ -1,0 +1,37 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { getSubmissions, type SubmissionRecord } from "../../../lib/submission-store";
+
+interface Props { submissions: SubmissionRecord[]; }
+
+export const getServerSideProps: GetServerSideProps<Props> = async () => ({
+  props: { submissions: await getSubmissions() },
+});
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString();
+}
+
+export default function SubmissionIndexPage({ submissions }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return <>
+    <Head><title>Submissions | Article6 Internal</title><meta name="robots" content="noindex,nofollow" /></Head>
+    <main className="min-h-screen bg-gray-50 px-4 py-12 text-gray-900"><div className="mx-auto max-w-6xl">
+      <p className="text-sm font-semibold uppercase tracking-wide text-forest-700">Article6 internal tool</p>
+      <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
+        <div><h1 className="text-2xl font-bold tracking-tight">Submissions</h1><p className="mt-2 text-sm text-gray-600">Internal review queue</p></div>
+        <Link href="/internal/submissions/new" className="rounded-md bg-forest-700 px-4 py-2 text-sm font-medium text-white hover:bg-forest-800">New submission</Link>
+      </div>
+      <div className="mt-8 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+        {submissions.length === 0 ? <p className="p-6 text-sm text-gray-600">No submissions yet.</p> : <div className="overflow-x-auto"><table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+          <thead className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500"><tr>
+            <th className="px-5 py-3">Reference</th><th className="px-5 py-3">Project</th><th className="px-5 py-3">Organization</th><th className="px-5 py-3">Methodology</th><th className="px-5 py-3">Status</th><th className="px-5 py-3">Submitted date</th><th className="px-5 py-3">Action</th>
+          </tr></thead>
+          <tbody className="divide-y divide-gray-100">{submissions.map((submission) => <tr key={submission.reference} className="text-gray-700">
+            <td className="whitespace-nowrap px-5 py-4 font-medium text-gray-900">{submission.reference}</td><td className="px-5 py-4">{submission.project}</td><td className="px-5 py-4">{submission.organization}</td><td className="px-5 py-4">{submission.methodology}</td><td className="whitespace-nowrap px-5 py-4">{submission.status}</td><td className="whitespace-nowrap px-5 py-4">{formatDate(submission.createdAt)}</td><td className="whitespace-nowrap px-5 py-4"><Link className="font-medium text-forest-700 hover:text-forest-800" href={`/internal/submissions/${submission.reference}`}>View</Link></td>
+          </tr>)}</tbody>
+        </table></div>}
+      </div>
+    </div></main>
+  </>;
+}

--- a/tests/submissions.test.ts
+++ b/tests/submissions.test.ts
@@ -3,7 +3,7 @@ import { createHmac } from "node:crypto";
 import fs from "node:fs";
 import test from "node:test";
 import { buildEmailHtml, buildEmailText, getInternalSubmissionUrl, normalizeEmailSubjectProject } from "../lib/email.ts";
-import { generatePresignedUploadUrl, resolveUploadReference } from "../lib/r2.ts";
+import { generatePresignedDownloadUrl, generatePresignedUploadUrl, resolveUploadReference } from "../lib/r2.ts";
 import { generateSubmissionReference } from "../lib/submission-reference.ts";
 import { getAppLayoutKind } from "../lib/layout.ts";
 import { buildSubmissionRecord } from "../lib/submission-store.ts";
@@ -194,6 +194,49 @@ test("internal submission detail route is protected by the existing internal mid
   assert.doesNotMatch(detail, /objectKey|bucket|presigned|r2\.cloudflarestorage/);
 });
 
+test("internal submissions index queries newest submissions first and links to detail", () => {
+  const store = fs.readFileSync(new URL("../lib/submission-store.ts", import.meta.url), "utf8");
+  const index = fs.readFileSync(new URL("../pages/internal/submissions/index.tsx", import.meta.url), "utf8");
+  assert.match(store, /export async function getSubmissions/);
+  assert.match(store, /ORDER BY created_at DESC/);
+  assert.match(index, /getServerSideProps/);
+  assert.match(index, /Reference/);
+  assert.match(index, /Submitted date/);
+  assert.match(index, /`\/internal\/submissions\/\$\{submission\.reference\}`/);
+});
+
+test("submission PDF download requires the internal session and signs the stored object", () => {
+  const route = fs.readFileSync(new URL("../pages/api/internal/submissions/[reference]/download.ts", import.meta.url), "utf8");
+  assert.match(route, /hasInternalUploadSession/);
+  assert.match(route, /status\(401\)/);
+  assert.match(route, /getSubmissionByReference/);
+  assert.match(route, /verifyObjectExists\(submission\.objectKey, submission\.bucket\)/);
+  assert.match(route, /generatePresignedDownloadUrl\(submission\.bucket, submission\.objectKey\)/);
+  assert.match(route, /res\.redirect\(307/);
+  assert.match(route, /status\(404\)/);
+});
+
+test("R2 download signing uses the persisted bucket and short-lived GET URL", async () => {
+  const previous = {
+    account: process.env.R2_ACCOUNT_ID,
+    access: process.env.R2_ACCESS_KEY_ID,
+    secret: process.env.R2_SECRET_ACCESS_KEY,
+    bucket: process.env.R2_BUCKET_NAME,
+  };
+  process.env.R2_ACCOUNT_ID = "synthetic-account";
+  process.env.R2_ACCESS_KEY_ID = "synthetic-access-key";
+  process.env.R2_SECRET_ACCESS_KEY = "synthetic-secret-key";
+  process.env.R2_BUCKET_NAME = "configured-bucket";
+  const url = await generatePresignedDownloadUrl("persisted-bucket", "submissions/2026-08-02/123e4567-e89b-12d3-a456-426614174000.pdf");
+  assert.equal(new URL(url).hostname, "persisted-bucket.synthetic-account.r2.cloudflarestorage.com");
+  assert.match(url, /persisted-bucket/);
+  assert.match(url, /X-Amz-Expires=300/);
+  for (const [key, value] of Object.entries({ R2_ACCOUNT_ID: previous.account, R2_ACCESS_KEY_ID: previous.access, R2_SECRET_ACCESS_KEY: previous.secret, R2_BUCKET_NAME: previous.bucket })) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
 test("internal notification text works without workEmail and identifies source", () => {
   const text = buildEmailText({
     contactName: "Synthetic Contact",
@@ -283,7 +326,7 @@ test("internal layout renders only the compact internal header", () => {
   assert.match(header, /Article6 Internal/);
   assert.match(header, /<Link href="\/internal\/submissions\/new"[\s\S]*>\s*Article6 Internal\s*<\/Link>/);
   assert.match(header, /href="\/internal\/submissions\/new"[\s\S]*onClick=\{resetInternalPage\}/);
-  assert.doesNotMatch(header, /href="\/internal\/submissions"/);
+  assert.match(header, /href="\/internal\/submissions"/);
   assert.doesNotMatch(header, /NavBar|Footer|Layout|Sign out|signout/);
 });
 


### PR DESCRIPTION
## Summary

- add the protected internal submissions review queue, sorted newest first
- add internal navigation to the queue
- enable secure PDF downloads through an authenticated server route and short-lived private R2 signed GET URLs
- add coverage for list ordering, authorization, missing objects, and signed download generation

## Scope

Quick Check execution and upload flow remain unchanged. No database migration is required.

## Checks

- npm test
- npx tsc --noEmit
- npm run lint
- git diff --check

Note: `next build` compiled and completed type checking but did not emit its final summary in the local environment, so the process was stopped after it stalled.