### PR TITLE
Implement internal submission Quick Check execution

### DIFF
--- a/lib/quick-check.ts
+++ b/lib/quick-check.ts
@@ -1,0 +1,24 @@
+export interface QuickCheckResult {
+  version: 1;
+  fileSize: number;
+  isPdf: boolean;
+  pageCount: number | null;
+  extractedTextPreview: string;
+  checks: { name: string; passed: boolean; detail: string }[];
+}
+
+/** The first pipeline stage: validate the private PDF and retain a small audit preview. */
+export function runQuickCheck(document: Buffer): QuickCheckResult {
+  const isPdf = document.subarray(0, 5).toString("ascii") === "%PDF-";
+  const text = document.toString("latin1").replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]+/g, " ").replace(/\s+/g, " ").trim();
+  const preview = text.slice(0, 2000);
+  const pageMatches = text.match(/\/Type\s*\/Page(?=\s|\/|>|$)/g);
+  return {
+    version: 1, fileSize: document.length, isPdf,
+    pageCount: pageMatches?.length || null, extractedTextPreview: preview,
+    checks: [
+      { name: "pdf_signature", passed: isPdf, detail: isPdf ? "PDF signature detected." : "PDF signature is missing." },
+      { name: "non_empty", passed: document.length > 0, detail: document.length > 0 ? "Document is non-empty." : "Document is empty." },
+    ],
+  };
+}

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -164,6 +164,13 @@ export async function verifyObjectExists(key: string, bucket?: string): Promise<
   }
 }
 
+export async function getPrivateObject(key: string, bucket?: string): Promise<Buffer> {
+  if (!bucket || !isApprovedSubmissionKey(key)) throw new Error("Invalid stored submission object.");
+  const response = await getS3Client().send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+  if (!response.Body) throw new Error("Stored submission object has no body.");
+  return Buffer.from(await response.Body.transformToByteArray());
+}
+
 export function getBucketName(): string {
   return getR2Credentials().bucketName;
 }

--- a/lib/submission-store.ts
+++ b/lib/submission-store.ts
@@ -3,12 +3,15 @@ import { Pool, type QueryResultRow } from "pg";
 import type { SubmissionSource } from "./submissions";
 
 export type SubmissionStatus = "received" | "in_review" | "completed" | "rejected";
+export type QuickCheckStatus = "received" | "processing" | "completed" | "failed";
 
 export interface SubmissionRecord {
   id: string; reference: string; objectKey: string; bucket: string; originalFilename: string;
   fileSize: number; contentType: string; project: string; organization: string; contactName: string;
   workEmail?: string; externalContact?: string; submissionSource: SubmissionSource; methodology: string;
   notes: string; status: SubmissionStatus; createdAt: string; updatedAt: string;
+  quickCheckStatus: QuickCheckStatus; quickCheckId?: string; quickCheckResult?: unknown;
+  quickCheckStartedAt?: string; quickCheckCompletedAt?: string; quickCheckFailedAt?: string; quickCheckError?: string;
 }
 
 export interface NewSubmissionRecord {
@@ -44,6 +47,13 @@ function toRecord(row: QueryResultRow): SubmissionRecord {
     workEmail: row.work_email || undefined, externalContact: row.external_contact || undefined,
     submissionSource: row.submission_source as SubmissionSource, methodology: String(row.methodology), notes: String(row.notes || ""),
     status: row.status as SubmissionStatus, createdAt: new Date(row.created_at).toISOString(), updatedAt: new Date(row.updated_at).toISOString(),
+    quickCheckStatus: (row.quick_check_status || "received") as QuickCheckStatus,
+    quickCheckId: row.quick_check_id ? String(row.quick_check_id) : undefined,
+    quickCheckResult: row.quick_check_result || undefined,
+    quickCheckStartedAt: row.quick_check_started_at ? new Date(row.quick_check_started_at).toISOString() : undefined,
+    quickCheckCompletedAt: row.quick_check_completed_at ? new Date(row.quick_check_completed_at).toISOString() : undefined,
+    quickCheckFailedAt: row.quick_check_failed_at ? new Date(row.quick_check_failed_at).toISOString() : undefined,
+    quickCheckError: row.quick_check_error || undefined,
   };
 }
 
@@ -52,7 +62,7 @@ export function buildSubmissionRecord(input: NewSubmissionRecord): SubmissionRec
     originalFilename: input.originalFilename, fileSize: input.fileSize, contentType: input.contentType, project: input.project,
     organization: input.organization, contactName: input.contactName, workEmail: input.workEmail, externalContact: input.externalContact,
     submissionSource: input.submissionSource, methodology: input.methodology, notes: input.notes, status: input.status || "received",
-    createdAt: input.createdAt, updatedAt: input.createdAt };
+    createdAt: input.createdAt, updatedAt: input.createdAt, quickCheckStatus: "received" };
 }
 
 export async function createSubmission(input: NewSubmissionRecord): Promise<SubmissionRecord> {
@@ -95,4 +105,35 @@ export async function getSubmissionByReference(reference: string): Promise<Submi
 export async function getSubmissions(): Promise<SubmissionRecord[]> {
   const result = await getPool().query("SELECT * FROM submissions ORDER BY created_at DESC");
   return result.rows.map(toRecord);
+}
+
+export async function startQuickCheck(reference: string, quickCheckId: string, startedAt: string): Promise<SubmissionRecord | null> {
+  const result = await getPool().query(
+    `UPDATE submissions SET quick_check_status = 'processing', quick_check_id = $2, quick_check_result = NULL,
+       quick_check_started_at = $3, quick_check_completed_at = NULL, quick_check_failed_at = NULL,
+       quick_check_error = NULL, updated_at = $3
+     WHERE reference = $1 AND quick_check_status <> 'processing' RETURNING *`,
+    [reference, quickCheckId, startedAt]
+  );
+  return result.rows[0] ? toRecord(result.rows[0]) : null;
+}
+
+export async function completeQuickCheck(reference: string, quickCheckId: string, resultData: unknown, completedAt: string): Promise<SubmissionRecord | null> {
+  const result = await getPool().query(
+    `UPDATE submissions SET quick_check_status = 'completed', quick_check_result = $3,
+       quick_check_completed_at = $4, quick_check_error = NULL, updated_at = $4
+     WHERE reference = $1 AND quick_check_id = $2 RETURNING *`,
+    [reference, quickCheckId, JSON.stringify(resultData), completedAt]
+  );
+  return result.rows[0] ? toRecord(result.rows[0]) : null;
+}
+
+export async function failQuickCheck(reference: string, quickCheckId: string, errorMessage: string, failedAt: string): Promise<SubmissionRecord | null> {
+  const result = await getPool().query(
+    `UPDATE submissions SET quick_check_status = 'failed', quick_check_error = $3,
+       quick_check_failed_at = $4, updated_at = $4
+     WHERE reference = $1 AND quick_check_id = $2 RETURNING *`,
+    [reference, quickCheckId, errorMessage.slice(0, 1000), failedAt]
+  );
+  return result.rows[0] ? toRecord(result.rows[0]) : null;
 }

--- a/migrations/002_add_quick_check.sql
+++ b/migrations/002_add_quick_check.sql
@@ -1,0 +1,8 @@
+ALTER TABLE submissions
+  ADD COLUMN IF NOT EXISTS quick_check_status VARCHAR(32) NOT NULL DEFAULT 'received',
+  ADD COLUMN IF NOT EXISTS quick_check_id UUID,
+  ADD COLUMN IF NOT EXISTS quick_check_result JSONB,
+  ADD COLUMN IF NOT EXISTS quick_check_started_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS quick_check_completed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS quick_check_failed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS quick_check_error TEXT;

--- a/pages/api/internal/submissions/[reference]/quick-check.ts
+++ b/pages/api/internal/submissions/[reference]/quick-check.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { hasInternalUploadSession } from "../../../../../lib/internal-auth";
+import { getPrivateObject, verifyObjectExists } from "../../../../../lib/r2";
+import { runQuickCheck } from "../../../../../lib/quick-check";
+import { completeQuickCheck, failQuickCheck, getSubmissionByReference, startQuickCheck } from "../../../../../lib/submission-store";
+import { isSubmissionReference } from "../../../../../lib/submissions";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!(await hasInternalUploadSession(req))) return res.status(401).json({ error: "Authentication required." });
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed." });
+  const reference = req.query.reference;
+  if (!isSubmissionReference(reference)) return res.status(404).json({ error: "Submission not found." });
+  const submission = await getSubmissionByReference(reference);
+  if (!submission) return res.status(404).json({ error: "Submission not found." });
+  if (!submission.bucket || !submission.objectKey) return res.status(404).json({ error: "Submission PDF is not available." });
+  try {
+    const object = await verifyObjectExists(submission.objectKey, submission.bucket);
+    if (!object.exists) return res.status(404).json({ error: "Submission PDF is not available." });
+    const quickCheckId = randomUUID();
+    const started = await startQuickCheck(reference, quickCheckId, new Date().toISOString());
+    if (!started) return res.status(409).json({ error: "A Quick Check is already processing." });
+    try {
+      const result = runQuickCheck(await getPrivateObject(submission.objectKey, submission.bucket));
+      const completed = await completeQuickCheck(reference, quickCheckId, result, new Date().toISOString());
+      return res.status(200).json({ status: completed?.quickCheckStatus || "completed", quickCheckId, result });
+    } catch (error) {
+      await failQuickCheck(reference, quickCheckId, error instanceof Error ? error.message : String(error), new Date().toISOString());
+      throw error;
+    }
+  } catch (error) {
+    console.error("[submissions] Quick Check failed", { reference, error });
+    return res.status(502).json({ error: "Unable to run Quick Check." });
+  }
+}

--- a/pages/internal/submissions/[reference].tsx
+++ b/pages/internal/submissions/[reference].tsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { useState } from "react";
 import { getSubmissionByReference, type SubmissionRecord } from "../../../lib/submission-store";
 import { isSubmissionReference } from "../../../lib/submissions";
 
@@ -17,6 +18,20 @@ function Detail({ label, value }: { label: string; value: string }) {
 }
 
 export default function SubmissionDetailPage({ submission }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [quickCheckStatus, setQuickCheckStatus] = useState(submission.quickCheckStatus);
+  const [quickCheckId, setQuickCheckId] = useState(submission.quickCheckId);
+  const [quickCheckError, setQuickCheckError] = useState<string>();
+  async function runCheck() {
+    setQuickCheckStatus("processing"); setQuickCheckError(undefined);
+    try {
+      const response = await fetch(`/api/internal/submissions/${submission.reference}/quick-check`, { method: "POST" });
+      const body = await response.json() as { status?: typeof quickCheckStatus; quickCheckId?: string; error?: string };
+      if (!response.ok) { setQuickCheckStatus("failed"); setQuickCheckError(body.error || "Unable to run Quick Check."); return; }
+      setQuickCheckStatus(body.status || "completed"); setQuickCheckId(body.quickCheckId);
+    } catch {
+      setQuickCheckStatus("failed"); setQuickCheckError("Unable to reach the Quick Check service.");
+    }
+  }
   return <>
     <Head><title>{submission.reference} | Article6 Internal</title><meta name="robots" content="noindex,nofollow" /></Head>
     <main className="min-h-screen bg-gray-50 px-4 py-12 text-gray-900"><div className="mx-auto max-w-3xl">
@@ -28,9 +43,9 @@ export default function SubmissionDetailPage({ submission }: InferGetServerSideP
         <Detail label="External contact" value={submission.externalContact || ""} /><Detail label="Methodology" value={submission.methodology} />
         <Detail label="Source" value={submission.submissionSource} /><Detail label="Original filename" value={submission.originalFilename} />
         <Detail label="File size" value={`${(submission.fileSize / (1024 * 1024)).toFixed(2)} MiB`} />
-        <Detail label="Submitted" value={new Date(submission.createdAt).toLocaleString()} /><Detail label="Status" value={submission.status} />
+        <Detail label="Submitted" value={new Date(submission.createdAt).toLocaleString()} /><Detail label="Status" value={submission.status} /><Detail label="Quick Check" value={quickCheckStatus} />
       </dl><div className="mt-6 border-t border-gray-100 pt-6"><Detail label="Notes" value={submission.notes} /></div>
-      <div className="mt-8 flex flex-wrap gap-3 border-t border-gray-100 pt-6"><a href={`/api/internal/submissions/${submission.reference}/download`} className="rounded-md bg-forest-700 px-4 py-2 text-sm font-medium text-white hover:bg-forest-800">Download PDF</a><button type="button" disabled className="rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-500">Run Quick Check</button></div>
+      <div className="mt-8 flex flex-wrap items-center gap-3 border-t border-gray-100 pt-6"><a href={`/api/internal/submissions/${submission.reference}/download`} className="rounded-md bg-forest-700 px-4 py-2 text-sm font-medium text-white hover:bg-forest-800">Download PDF</a><button type="button" onClick={runCheck} disabled={quickCheckStatus === "processing"} className="rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 disabled:cursor-wait disabled:opacity-60">{quickCheckStatus === "processing" ? "Running Quick Check…" : "Run Quick Check"}</button>{quickCheckStatus === "completed" && quickCheckId && <span className="text-sm text-gray-600">Result available (audit {quickCheckId})</span>}{quickCheckStatus === "failed" && <span className="text-sm text-red-700">{quickCheckError || "Quick Check failed."}</span>}</div>
       </div>
     </div></main>
   </>;

--- a/tests/submissions.test.ts
+++ b/tests/submissions.test.ts
@@ -7,6 +7,7 @@ import { generatePresignedDownloadUrl, generatePresignedUploadUrl, resolveUpload
 import { generateSubmissionReference } from "../lib/submission-reference.ts";
 import { getAppLayoutKind } from "../lib/layout.ts";
 import { buildSubmissionRecord } from "../lib/submission-store.ts";
+import { runQuickCheck } from "../lib/quick-check.ts";
 import {
   isApprovedSubmissionKey,
   isPdfUpload,
@@ -214,6 +215,40 @@ test("submission PDF download requires the internal session and signs the stored
   assert.match(route, /generatePresignedDownloadUrl\(submission\.bucket, submission\.objectKey\)/);
   assert.match(route, /res\.redirect\(307/);
   assert.match(route, /status\(404\)/);
+});
+
+test("Quick Check validates a private PDF and returns an auditable result", () => {
+  const result = runQuickCheck(Buffer.from("%PDF-1.7 /Type /Page /Type /Page"));
+  assert.equal(result.isPdf, true);
+  assert.equal(result.pageCount, 2);
+  assert.equal(result.checks.every((check) => check.passed), true);
+  assert.equal(runQuickCheck(Buffer.from("not a pdf")).isPdf, false);
+});
+
+test("Quick Check route requires auth, resolves the submission, verifies R2, and persists completion", () => {
+  const route = fs.readFileSync(new URL("../pages/api/internal/submissions/[reference]/quick-check.ts", import.meta.url), "utf8");
+  const store = fs.readFileSync(new URL("../lib/submission-store.ts", import.meta.url), "utf8");
+  assert.match(route, /hasInternalUploadSession/);
+  assert.match(route, /status\(401\)/);
+  assert.match(route, /getSubmissionByReference/);
+  assert.match(route, /verifyObjectExists\(submission\.objectKey, submission\.bucket\)/);
+  assert.match(route, /getPrivateObject\(submission\.objectKey, submission\.bucket\)/);
+  assert.match(route, /runQuickCheck/);
+  assert.match(route, /startQuickCheck/);
+  assert.match(route, /completeQuickCheck/);
+  assert.match(route, /failQuickCheck/);
+  assert.match(store, /quick_check_status = 'processing'/);
+  assert.match(store, /quick_check_status = 'completed'/);
+  assert.match(store, /quick_check_status = 'failed'/);
+});
+
+test("Quick Check migration preserves the existing upload schema and stores an audit result", () => {
+  const migration = fs.readFileSync(new URL("../migrations/002_add_quick_check.sql", import.meta.url), "utf8");
+  assert.match(migration, /ADD COLUMN IF NOT EXISTS quick_check_status/);
+  assert.match(migration, /quick_check_id UUID/);
+  assert.match(migration, /quick_check_result JSONB/);
+  assert.match(migration, /quick_check_started_at/);
+  assert.match(migration, /quick_check_completed_at/);
 });
 
 test("R2 download signing uses the persisted bucket and short-lived GET URL", async () => {


### PR DESCRIPTION
## What changed
- activate Run Quick Check on internal submission detail pages
- authenticate and resolve the submission, verify its private R2 object, download it server-side, and execute Quick Check
- persist Quick Check status, audit ID, result JSON, timestamps, and failure details
- add minimal processing/completed/failed UI states and coverage

## Validation
- npm test
- npx tsc --noEmit
- npm run lint
- git diff --check

## Notes
- Added migrations/002_add_quick_check.sql; it must be applied before deploying this branch.
- No production test data was created or modified.
- The current repository had no pre-existing Quick Check extractor, so this PR adds the initial PDF sanity/text-preview pipeline; a richer parser can consume the persisted versioned result later.