### PR TITLE
Raise Article6 PDF upload limit to 150 MiB

### DIFF
--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -1,4 +1,4 @@
-export const MAX_FILE_SIZE = 50 * 1024 * 1024;
+export const MAX_FILE_SIZE = 150 * 1024 * 1024;
 export const PDF_CONTENT_TYPE = "application/pdf";
 
 export type SubmissionSource = "website" | "whatsapp" | "email" | "internal" | "other";
@@ -79,7 +79,7 @@ export function validateSubmissionMetadata(
     return "Invalid file size.";
   }
   if (value.fileSize > MAX_FILE_SIZE) {
-    return "File size must be under 50MB.";
+    return "File size must be under 150MB.";
   }
   return null;
 }
@@ -87,7 +87,7 @@ export function validateSubmissionMetadata(
 export function isPdfUpload(file: { type: string; size: number }): string | null {
   if (file.type !== PDF_CONTENT_TYPE) return "Only PDF files are accepted.";
   if (file.size <= 0) return "The selected file is empty.";
-  if (file.size > MAX_FILE_SIZE) return "File size must be under 50MB.";
+  if (file.size > MAX_FILE_SIZE) return "File size must be under 150MB.";
   return null;
 }
 
@@ -101,7 +101,7 @@ export function validateStoredObject(
 ): string | null {
   if (!object.exists) return "Uploaded file not found.";
   if (object.size <= 0) return "Uploaded file is empty.";
-  if (object.size > MAX_FILE_SIZE) return "Uploaded file exceeds the 50MB limit.";
+  if (object.size > MAX_FILE_SIZE) return "Uploaded file exceeds the 150MB limit.";
   if (object.size !== declaredSize) return "Uploaded file size does not match the declared file size.";
   if (object.contentType !== PDF_CONTENT_TYPE) return "Uploaded file is not a valid PDF.";
   return null;

--- a/tests/submissions.test.ts
+++ b/tests/submissions.test.ts
@@ -42,7 +42,9 @@ test("optional email is validated when supplied", () => {
 
 test("file size boundaries, empty files, and content type are enforced", () => {
   assert.equal(validateSubmissionMetadata({ ...base, submissionSource: "internal", fileSize: MAX_FILE_SIZE - 1 }), null);
-  assert.match(validateSubmissionMetadata({ ...base, submissionSource: "internal", fileSize: MAX_FILE_SIZE + 1 }) || "", /50MB/i);
+  assert.equal(validateSubmissionMetadata({ ...base, submissionSource: "internal", fileSize: MAX_FILE_SIZE }), null);
+  assert.match(validateSubmissionMetadata({ ...base, submissionSource: "internal", fileSize: MAX_FILE_SIZE + 1 }) || "", /150MB/i);
+  assert.equal(isPdfUpload({ type: "application/pdf", size: MAX_FILE_SIZE }), null);
   assert.match(isPdfUpload({ type: "application/pdf", size: 0 }) || "", /empty/i);
   assert.match(isPdfUpload({ type: "text/plain", size: 10 }) || "", /PDF/i);
 });
@@ -72,7 +74,7 @@ test("original filenames are sanitized for safe download headers", () => {
 test("confirmation rejects missing, mismatched, oversized, and non-PDF objects", () => {
   assert.match(validateStoredObject({ exists: false, size: 0 }, 1) || "", /not found/i);
   assert.match(validateStoredObject({ exists: true, size: 100 }, 99) || "", /match/i);
-  assert.match(validateStoredObject({ exists: true, size: MAX_FILE_SIZE + 1 }, MAX_FILE_SIZE + 1) || "", /50MB/i);
+  assert.match(validateStoredObject({ exists: true, size: MAX_FILE_SIZE + 1 }, MAX_FILE_SIZE + 1) || "", /150MB/i);
   assert.match(validateStoredObject({ exists: true, size: 100, contentType: "text/plain" }, 100) || "", /PDF/i);
   assert.match(validateStoredObject({ exists: true, size: 100 }, 100) || "", /PDF/i);
 });


### PR DESCRIPTION
## Summary\n\n- raise the canonical Article6 private PDF upload limit from 50 MiB to 150 MiB\n- update metadata, browser, and stored-object validation messages\n- add exact-limit and over-limit regression coverage while preserving empty/non-PDF and R2 mismatch checks\n\n## Validation\n\n- node --test tests/submissions.test.ts\n- npx eslint lib/submissions.ts tests/submissions.test.ts components/preview/PddUploadForm.tsx\n- npx tsc --noEmit\n- git diff --check\n\nNo migration or environment change is required.