### PR TITLE
Clean up production positioning and routes

### DIFF
--- a/components/VerificationReadinessHome.tsx
+++ b/components/VerificationReadinessHome.tsx
@@ -2,16 +2,16 @@ import PreviewHero from './preview/PreviewHero';
 import PddUploadForm from './preview/PddUploadForm';
 import Link from 'next/link';
 
-const SAMPLE_ASSESSMENT_PATH = '/preview/verification-readiness/sample-assessment';
+const SAMPLE_ASSESSMENT_PATH = '/sample-assessment';
 
 export default function VerificationReadinessHome() {
   return (
     <>
       {/* 1. Hero */}
       <PreviewHero
-        eyebrow="VM0007 v1.8 EVIDENCE READINESS"
+        eyebrow="PRE-VALIDATION EVIDENCE READINESS"
         headline="Find the evidence gaps before your validator does."
-        body="Article6 reviews your VM0007 v1.8 project documentation against methodology requirements to identify missing, unclear, and unsupported evidence before validation begins."
+        body="Article6 reviews project documentation against applicable methodology requirements to identify missing, unclear, and unsupported evidence before validation begins."
         trustLine="Independent pre-validation review. No commitment required for initial scope review."
         primaryCta={{ label: 'Upload your PDD', href: '#upload-pdd' }}
         secondaryCta={{ label: 'View Sample Assessment', href: SAMPLE_ASSESSMENT_PATH }}

--- a/components/preview/PreviewFooter.tsx
+++ b/components/preview/PreviewFooter.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import Link from 'next/link';
-import { previewNavigationLinks } from './navigation';
+import { getPreviewNavigationLinks } from './navigation';
+import { useRouter } from 'next/router';
 import Logo from '../Logo';
 
-const BASE = '/preview/verification-readiness';
+const PREVIEW_BASE = '/preview/verification-readiness';
 
 const PreviewFooter: React.FC = () => {
+  const router = useRouter();
+  const isPreview = router.pathname.startsWith(PREVIEW_BASE);
+  const navigationLinks = getPreviewNavigationLinks(isPreview);
   return (
     <footer className="border-t border-gray-200 bg-white">
       <div className="mx-auto max-w-6xl px-4 py-10 md:py-12">
-        <Logo href={BASE} />
+        <Logo href={isPreview ? PREVIEW_BASE : '/'} />
         <p className="mt-2 text-sm text-gray-500">
           Evidence readiness assessments for carbon projects.
         </p>
@@ -18,7 +22,7 @@ const PreviewFooter: React.FC = () => {
           verification body.
         </p>
         <div className="mt-5 flex flex-wrap gap-x-5 gap-y-1">
-          {previewNavigationLinks.map(({ href, label }) => (
+          {navigationLinks.map(({ href, label }) => (
             <Link
               key={href}
               href={href}

--- a/components/preview/PreviewHeader.tsx
+++ b/components/preview/PreviewHeader.tsx
@@ -2,16 +2,19 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
-import { previewNavigationLinks, previewCtaLink } from './navigation';
+import { getPreviewNavigationLinks, getPreviewCtaLink } from './navigation';
 import Logo from '../Logo';
 
-const BASE = '/preview/verification-readiness';
+const PREVIEW_BASE = '/preview/verification-readiness';
 
 const PreviewHeader: React.FC = () => {
   const [open, setOpen] = useState(false);
   const router = useRouter();
-  const isHomePage = router.pathname === '/' || router.pathname === '/preview/verification-readiness';
-  const brandHref = router.pathname === '/' ? '/' : BASE;
+  const isPreview = router.pathname.startsWith(PREVIEW_BASE);
+  const isHomePage = router.pathname === '/' || router.pathname === PREVIEW_BASE;
+  const navigationLinks = getPreviewNavigationLinks(isPreview);
+  const ctaLink = getPreviewCtaLink(isPreview);
+  const brandHref = isPreview ? PREVIEW_BASE : '/';
 
   useEffect(() => {
     const handleResize = () => {
@@ -38,17 +41,17 @@ const PreviewHeader: React.FC = () => {
             }
           }}
         >
-          {previewCtaLink.label}
+          {ctaLink.label}
         </a>
       );
     }
     return (
       <Link
-        href={previewCtaLink.href}
+        href={ctaLink.href}
         className={`inline-flex items-center rounded-md bg-forest-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-forest-800 ${className}`}
         onClick={() => setOpen(false)}
       >
-        {previewCtaLink.label}
+          {ctaLink.label}
       </Link>
     );
   };
@@ -59,7 +62,7 @@ const PreviewHeader: React.FC = () => {
         <Logo href={brandHref} />
 
         <ul className="hidden md:flex items-center gap-6">
-          {previewNavigationLinks.map(({ href, label }) => {
+          {navigationLinks.map(({ href, label }) => {
             const isActive = router.asPath === href || router.asPath.startsWith(href + '/');
             return (
               <li key={href}>
@@ -106,7 +109,7 @@ const PreviewHeader: React.FC = () => {
       {open && (
         <div id="preview-mobile-menu" className="md:hidden border-t border-gray-200 bg-white">
           <ul className="flex flex-col px-4 py-3 gap-1.5">
-            {previewNavigationLinks.map(({ href, label }) => {
+            {navigationLinks.map(({ href, label }) => {
               const isActive = router.asPath === href || router.asPath.startsWith(href + '/');
               return (
                 <li key={href}>

--- a/components/preview/navigation.ts
+++ b/components/preview/navigation.ts
@@ -3,14 +3,20 @@ export interface PreviewNavLink {
   label: string;
 }
 
-const BASE = '/preview/verification-readiness';
+const PREVIEW_BASE = '/preview/verification-readiness';
+const PRODUCTION_BASE = '';
 
-export const previewNavigationLinks: PreviewNavLink[] = [
-  { href: `${BASE}/sample-assessment`, label: 'Sample Report' },
-  { href: `${BASE}/how-it-works`, label: 'How It Works' },
-];
+export function getPreviewNavigationLinks(isPreview: boolean): PreviewNavLink[] {
+  const base = isPreview ? PREVIEW_BASE : PRODUCTION_BASE;
+  return [
+    { href: `${base}/sample-assessment`, label: 'Sample Report' },
+    { href: `${base}/how-it-works`, label: 'How It Works' },
+  ];
+}
 
-export const previewCtaLink: PreviewNavLink = {
-  href: `${BASE}#upload-pdd`,
-  label: 'Upload PDD',
-};
+export function getPreviewCtaLink(isPreview: boolean): PreviewNavLink {
+  return {
+    href: `${isPreview ? PREVIEW_BASE : '/'}#upload-pdd`,
+    label: 'Upload PDD',
+  };
+}

--- a/lib/layout.ts
+++ b/lib/layout.ts
@@ -1,7 +1,8 @@
-export type AppLayoutKind = "marketing" | "preview" | "internal";
+export type AppLayoutKind = "marketing" | "preview" | "readiness" | "internal";
 
 export function getAppLayoutKind(pathname: string): AppLayoutKind {
   if (pathname.startsWith("/internal")) return "internal";
   if (pathname.startsWith("/preview/verification-readiness")) return "preview";
+  if (pathname === "/sample-assessment" || pathname === "/how-it-works") return "readiness";
   return "marketing";
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,7 +16,7 @@ function MyApp({ Component, pageProps, router }: AppProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         {layoutKind === 'preview' && <meta name="robots" content="noindex,nofollow" />}
       </Head>
-      {layoutKind === 'preview' ? (
+      {layoutKind === 'preview' || layoutKind === 'readiness' ? (
         <div style={{ fontFamily: "'Inter', system-ui, -apple-system, sans-serif" }}>
           <PreviewLayout>
             <Component {...pageProps} />

--- a/pages/how-it-works.tsx
+++ b/pages/how-it-works.tsx
@@ -1,0 +1,1 @@
+export { default } from './preview/verification-readiness/how-it-works';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ export default function HomePage() {
         <title>Article6 — Pre-Validation Evidence Readiness</title>
         <meta
           name="description"
-          content="Find evidence gaps before your validator does. Article6 reviews your VM0007 v1.8 project documentation against methodology requirements."
+          content="Find evidence gaps before your validator does. Article6 reviews project documentation against applicable methodology requirements to identify missing, unclear, and unsupported evidence before validation begins."
         />
       </Head>
       <VerificationReadinessHome />

--- a/pages/preview/verification-readiness/how-it-works.tsx
+++ b/pages/preview/verification-readiness/how-it-works.tsx
@@ -2,10 +2,14 @@ import Head from 'next/head';
 import SectionHeading from '../../../components/preview/SectionHeading';
 import ProcessStep from '../../../components/preview/ProcessStep';
 import Link from 'next/link';
-
-const BASE = '/preview/verification-readiness';
+import { useRouter } from 'next/router';
 
 export default function HowItWorksPage() {
+  const router = useRouter();
+  const base = router.pathname.startsWith('/preview/verification-readiness')
+    ? '/preview/verification-readiness'
+    : '/';
+
   return (
     <>
       <Head>
@@ -74,7 +78,7 @@ export default function HowItWorksPage() {
       {/* CTA */}
       <section className="mx-auto max-w-6xl px-4 pb-16 md:pb-24 text-center">
         <Link
-          href={`${BASE}#upload-pdd`}
+          href={`${base}#upload-pdd`}
           className="inline-flex items-center justify-center rounded-md bg-forest-700 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-forest-800"
         >
           Upload your PDD

--- a/pages/sample-assessment.tsx
+++ b/pages/sample-assessment.tsx
@@ -1,0 +1,1 @@
+export { default } from './preview/verification-readiness/sample-assessment';


### PR DESCRIPTION
## Summary

- make homepage positioning methodology-agnostic while retaining the core evidence-readiness message
- add production-facing /sample-assessment and /how-it-works routes by reusing the existing page components
- keep preview routes available with noindex,nofollow and preserve preview navigation behavior
- route public header/footer links and CTAs to production paths

## Scope

Intake fields, methodology handling, upload APIs, upload validation, storage, Quick Check, notifications, database persistence, R2 behavior, and internal submission pages were not changed. The configured upload limit remains 50 MB, so no upload-size copy correction was needed.

## Verification

- npm run lint: passed
- npm test: passed (38 tests)
- git diff --check: passed
- npm run typecheck: unavailable; no typecheck script exists
- npx tsc --noEmit: blocked by pre-existing missing module @vercel/analytics/next
- local route requests: blocked by the same missing module, returning 500 before page rendering
