### PR TITLE
Improve public proof and sample assessment

### DIFF
--- a/components/VerificationReadinessHome.tsx
+++ b/components/VerificationReadinessHome.tsx
@@ -24,20 +24,20 @@ export default function VerificationReadinessHome() {
               <div className="border border-forest-600/40 px-4 py-5 text-center">
                 <p className="text-[10px] uppercase tracking-[0.2em] text-forest-300">Article6</p>
                 <p className="text-xl font-bold text-white mt-3 leading-tight">
-                  VM0007 v1.8
+                  PRE-VALIDATION
                 </p>
                 <p className="text-xs text-forest-200 mt-1">
-                  REDD+ Methodology Framework
+                  EVIDENCE ASSESSMENT
                 </p>
                 <div className="mt-4 w-12 h-px bg-forest-600 mx-auto" />
                 <p className="text-xs text-forest-200 mt-3">
-                  Pre-Validation
+                  Methodology-Specific
                 </p>
                 <p className="text-xs text-forest-200">
-                  Evidence Assessment
+                  Project Readiness Review
                 </p>
                 <p className="text-[10px] text-forest-400 mt-3">
-                  Illustrative Client Deliverable
+                  Illustrative Deliverable
                 </p>
               </div>
             </div>
@@ -48,7 +48,7 @@ export default function VerificationReadinessHome() {
                 Readiness Dashboard
               </p>
               <p className="text-xs text-gray-500 mb-3">
-                58 methodology requirements reviewed
+                Methodology requirements reviewed
               </p>
               <div className="space-y-2">
                 {[
@@ -192,8 +192,8 @@ export default function VerificationReadinessHome() {
                 <p className="text-xs uppercase tracking-[0.15em] text-forest-200">
                   Evidence Readiness Assessment
                 </p>
-                <p className="text-lg font-bold mt-1.5">VM0007 v1.8</p>
-                <p className="text-forest-200 text-xs mt-1">Sample Report</p>
+                <p className="text-lg font-bold mt-1.5">Article6 Assessment</p>
+                <p className="text-forest-200 text-xs mt-1">Illustrative Report</p>
                 <div className="mt-4 border-t border-forest-600 pt-3 text-[10px] text-forest-200">
                   Prepared by Article6
                 </div>

--- a/components/preview/AssessmentStatusCard.tsx
+++ b/components/preview/AssessmentStatusCard.tsx
@@ -5,7 +5,13 @@ type Status = 'supported' | 'unclear' | 'action-required';
 interface AssessmentStatusCardProps {
   status: Status;
   title: string;
-  children: React.ReactNode;
+  context?: string;
+  evidence?: string;
+  gap?: string;
+  whyItMatters?: string;
+  requiredAction?: string;
+  resolution?: string;
+  children?: React.ReactNode;
 }
 
 const statusConfig: Record<Status, { label: string; dotClass: string; borderClass: string }> = {
@@ -26,7 +32,17 @@ const statusConfig: Record<Status, { label: string; dotClass: string; borderClas
   },
 };
 
-const AssessmentStatusCard: React.FC<AssessmentStatusCardProps> = ({ status, title, children }) => {
+const AssessmentStatusCard: React.FC<AssessmentStatusCardProps> = ({
+  status,
+  title,
+  context,
+  evidence,
+  gap,
+  whyItMatters,
+  requiredAction,
+  resolution,
+  children,
+}) => {
   const config = statusConfig[status];
 
   return (
@@ -40,7 +56,36 @@ const AssessmentStatusCard: React.FC<AssessmentStatusCardProps> = ({ status, tit
         </span>
       </div>
       <h4 className="text-base md:text-lg font-semibold text-forest-900">{title}</h4>
-      <p className="mt-2 text-sm text-gray-600 leading-relaxed">{children}</p>
+      {children ? (
+        <p className="mt-2 text-sm text-gray-600 leading-relaxed">{children}</p>
+      ) : (
+      <dl className="mt-4 grid gap-3 text-sm leading-relaxed">
+        <div>
+          <dt className="font-semibold text-gray-800">Requirement / review context</dt>
+          <dd className="text-gray-600">{context}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-gray-800">Evidence reviewed</dt>
+          <dd className="text-gray-600">{evidence}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-gray-800">Gap or issue identified</dt>
+          <dd className="text-gray-600">{gap}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-gray-800">Why it matters</dt>
+          <dd className="text-gray-600">{whyItMatters}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-gray-800">Required action</dt>
+          <dd className="text-gray-600">{requiredAction}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-gray-800">Resolution criterion</dt>
+          <dd className="text-gray-600">{resolution}</dd>
+        </div>
+      </dl>
+      )}
     </div>
   );
 };

--- a/pages/preview/verification-readiness/sample-assessment.tsx
+++ b/pages/preview/verification-readiness/sample-assessment.tsx
@@ -66,23 +66,23 @@ export default function SampleAssessmentPage() {
             />
             <AssessmentStatusCard
               status="action-required"
-              title="Sampling evidence is not yet demonstrably representative"
-              context="Monitoring and field sampling should support representative estimates for the project area and the reported monitoring period."
-              evidence="A sampling description and selected observations are present, but the sampling frame, selection method, and coverage by stratum are not fully evidenced."
-              gap="The reviewed material does not allow a reviewer to reproduce why the sample is representative of the stated project area."
-              whyItMatters="Weak representativeness support can undermine confidence in activity data and uncertainty treatment."
-              requiredAction="Provide the sampling frame, stratification logic, sample-size basis, locations or identifiers, and coverage reconciliation."
-              resolution="The sampling design and results can be traced from the project area and strata through to the reported estimate."
+              title="Sampling design is not sufficiently supported in the PDD"
+              context="The PDD should substantiate the sampling and stratification design required by the applicable methodology, including its basis for representativeness."
+              evidence="The PDD describes sampling and identifies strata, but the stratification logic and sample-size rationale, where applicable, are not fully supported by internal references."
+              gap="The PDD does not make it possible to trace how the proposed design supports representative coverage or remains consistent with the applicable methodology."
+              whyItMatters="An under-supported design creates an evidence-readiness gap before a validator can assess whether the PDD's approach is adequately justified."
+              requiredAction="Add the design basis, stratification logic, sample-size rationale where applicable, and clear PDD references supporting methodology consistency."
+              resolution="The PDD explains the sampling design and representativeness basis, with each element traceable to the applicable methodology and supporting section."
             />
             <AssessmentStatusCard
               status="unclear"
-              title="Requirement references are inconsistent across the evidence set"
-              context="The assessment checks whether requirement interpretations and evidence references remain consistent across the PDD, annexes, and calculations."
-              evidence="Several sections address the same control or parameter, but they use different internal references and version labels."
-              gap="A reviewer may not be able to determine which cited section or calculation is the controlling source."
-              whyItMatters="Broken traceability increases review time and makes later corrections harder to propagate safely."
-              requiredAction="Create a single reference map and align section, annex, calculation, and methodology-version citations."
-              resolution="Each assessed requirement has one unambiguous current reference, with superseded versions identified or removed."
+              title="Internal methodology references are inconsistent"
+              context="The PDD should use current, unambiguous internal references for each methodology requirement and the evidence supporting it."
+              evidence="Several PDD sections address the same requirement, but some section citations and methodology-version references do not align."
+              gap="Broken or outdated citations make it unclear which PDD section is the controlling reference for the assessed requirement."
+              whyItMatters="A validator may spend additional time resolving traceability defects or question whether the PDD applies the intended methodology version consistently."
+              requiredAction="Review the PDD's internal citations, update outdated methodology or version references, and identify one controlling section for each requirement."
+              resolution="Each assessed requirement has a current, unambiguous PDD reference, with broken citations corrected and superseded references removed or clearly marked."
             />
           </div>
         </div>

--- a/pages/preview/verification-readiness/sample-assessment.tsx
+++ b/pages/preview/verification-readiness/sample-assessment.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Link from 'next/link';
 import SectionHeading from '../../../components/preview/SectionHeading';
 import ReportPreview from '../../../components/preview/ReportPreview';
 import AssessmentStatusCard from '../../../components/preview/AssessmentStatusCard';
@@ -53,17 +54,36 @@ export default function SampleAssessmentPage() {
             Illustrative examples
           </p>
           <div className="mt-10 max-w-3xl mx-auto space-y-5">
-            <AssessmentStatusCard status="supported" title="Evidence supported">
-              Relevant project documentation was identified and clearly linked to the assessed
-              requirement.
-            </AssessmentStatusCard>
-            <AssessmentStatusCard status="unclear" title="Evidence unclear">
-              Related information was located, but the supporting basis or document traceability may
-              require clarification.
-            </AssessmentStatusCard>
-            <AssessmentStatusCard status="action-required" title="Action required">
-              Sufficient supporting evidence was not identified in the documents reviewed.
-            </AssessmentStatusCard>
+            <AssessmentStatusCard
+              status="unclear"
+              title="Carbon-pool selection needs a clearer basis"
+              context="Carbon pools included in the accounting boundary, and any exclusions, should be justified against the applicable methodology requirements."
+              evidence="The project description and emissions calculations identify the principal pools; supporting rationale for an excluded pool is not consistently referenced."
+              gap="The exclusion rationale is stated at a high level, but the supporting source or calculation boundary is not traceable from the reviewed documents."
+              whyItMatters="An unsupported exclusion can affect completeness of the baseline and project-emissions assessment."
+              requiredAction="Add a pool-by-pool applicability table with the exclusion basis and direct document or calculation references."
+              resolution="Every excluded pool has a documented applicability rationale that reconciles to the accounting boundary and cited evidence."
+            />
+            <AssessmentStatusCard
+              status="action-required"
+              title="Sampling evidence is not yet demonstrably representative"
+              context="Monitoring and field sampling should support representative estimates for the project area and the reported monitoring period."
+              evidence="A sampling description and selected observations are present, but the sampling frame, selection method, and coverage by stratum are not fully evidenced."
+              gap="The reviewed material does not allow a reviewer to reproduce why the sample is representative of the stated project area."
+              whyItMatters="Weak representativeness support can undermine confidence in activity data and uncertainty treatment."
+              requiredAction="Provide the sampling frame, stratification logic, sample-size basis, locations or identifiers, and coverage reconciliation."
+              resolution="The sampling design and results can be traced from the project area and strata through to the reported estimate."
+            />
+            <AssessmentStatusCard
+              status="unclear"
+              title="Requirement references are inconsistent across the evidence set"
+              context="The assessment checks whether requirement interpretations and evidence references remain consistent across the PDD, annexes, and calculations."
+              evidence="Several sections address the same control or parameter, but they use different internal references and version labels."
+              gap="A reviewer may not be able to determine which cited section or calculation is the controlling source."
+              whyItMatters="Broken traceability increases review time and makes later corrections harder to propagate safely."
+              requiredAction="Create a single reference map and align section, annex, calculation, and methodology-version citations."
+              resolution="Each assessed requirement has one unambiguous current reference, with superseded versions identified or removed."
+            />
           </div>
         </div>
       </section>
@@ -83,6 +103,12 @@ export default function SampleAssessmentPage() {
         >
           Download Sample Report (PDF)
         </a>
+        <p className="mt-5 text-sm text-gray-500">
+          Reviewing your own project documentation?{' '}
+          <Link href="/#upload-pdd" className="font-semibold text-forest-700 hover:text-forest-800">
+            Start with a scope review &rarr;
+          </Link>
+        </p>
       </section>
 
       {/* Disclaimer */}


### PR DESCRIPTION
## Summary
- make the homepage illustrative report/dashboard methodology-neutral
- replace generic sample-page status definitions with three structured diagnostic-style findings
- preserve the VM0007 v1.8 sample PDF and add a direct scope-review CTA

## Public proof changes
The homepage visual now presents Article6 as a methodology-specific project readiness review without implying VM0007-only coverage. The sample page remains explicitly VM0007 v1.8 and is clearly marked illustrative/redacted.

## Findings added
- Carbon-pool selection needs a clearer basis
- Sampling evidence is not yet demonstrably representative
- Requirement references are inconsistent across the evidence set

Each finding includes review context, evidence reviewed, gap, significance, required action, and resolution criterion.

## Validation
- `npm run lint` ✅
- `npm test` ✅ (38 tests)
- `git diff --check` ✅
- `npx tsc --noEmit` ⚠️ existing dependency issue: missing `@vercel/analytics/next`
- local browser verification ⚠️ `agent-browser` is unavailable; local Next rendering is also blocked by the same existing analytics dependency issue
- no migrations
- intake, backend, upload, Quick Check, storage, and notifications unchanged
