### PR TITLE
Instrument funnel analytics events

### DIFF
--- a/components/VerificationReadinessHome.tsx
+++ b/components/VerificationReadinessHome.tsx
@@ -1,10 +1,30 @@
 import PreviewHero from './preview/PreviewHero';
 import PddUploadForm from './preview/PddUploadForm';
 import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+import { trackEvent } from '../lib/analytics';
 
 const SAMPLE_ASSESSMENT_PATH = '/sample-assessment';
 
 export default function VerificationReadinessHome() {
+  const uploadSectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const section = uploadSectionRef.current;
+    if (!section || typeof IntersectionObserver === 'undefined') return;
+
+    let tracked = false;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting && !tracked) {
+        tracked = true;
+        trackEvent('upload_section_view');
+        observer.disconnect();
+      }
+    });
+    observer.observe(section);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <>
       {/* 1. Hero */}
@@ -14,6 +34,7 @@ export default function VerificationReadinessHome() {
         body="Article6 reviews project documentation against applicable methodology requirements to identify missing, unclear, and unsupported evidence before validation begins."
         trustLine="Independent pre-validation review. No commitment required for initial scope review."
         primaryCta={{ label: 'Upload your PDD', href: '#upload-pdd' }}
+        onPrimaryCtaClick={() => trackEvent('homepage_primary_cta', { location: 'hero' })}
         secondaryCta={{ label: 'View Sample Assessment', href: SAMPLE_ASSESSMENT_PATH }}
       >
         {/* Premium report preview */}
@@ -218,7 +239,7 @@ export default function VerificationReadinessHome() {
       </section>
 
       {/* 5. PDD upload form */}
-      <section id="upload-pdd" className="border-y border-gray-200 bg-gray-50 scroll-mt-16">
+      <section ref={uploadSectionRef} id="upload-pdd" className="border-y border-gray-200 bg-gray-50 scroll-mt-16">
         <div className="mx-auto max-w-6xl px-4 py-16 md:py-20">
           <div className="max-w-lg mx-auto">
             <h2 className="text-xl md:text-2xl font-bold tracking-tight text-gray-900">

--- a/components/preview/PddUploadForm.tsx
+++ b/components/preview/PddUploadForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { isPdfUpload, MAX_FILE_SIZE, type SubmissionSource } from '../../lib/submissions';
 import { useInternalReset } from '../InternalResetContext';
+import { trackEvent } from '../../lib/analytics';
 
 const inputClasses =
   'w-full rounded-md border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-forest-500 focus:border-forest-500 transition';
@@ -51,6 +52,9 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
     if (selectedFile) {
       setFile(selectedFile);
       setFileName(selectedFile.name);
+      if (!isInternal && isPdfUpload(selectedFile) === null) {
+        trackEvent('upload_file_selected');
+      }
     } else {
       setFile(null);
       setFileName('');
@@ -81,6 +85,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
 
     setPhase('uploading');
     setErrorMessage('');
+    if (!isInternal) trackEvent('scope_review_started');
 
     try {
       console.info('[PddUploadForm] Step 1: Requesting presigned URL', {
@@ -211,6 +216,7 @@ const PddUploadForm: React.FC<PddUploadFormProps> = ({ mode = 'public' }) => {
 
       setSubmissionId(confirmBody.submissionId);
       setPhase('success');
+      if (!isInternal) trackEvent('scope_review_submitted');
       console.info('[PddUploadForm] Upload flow complete', { submissionReference: confirmBody.submissionId });
     } catch (err) {
       console.error('[PddUploadForm] Upload flow error', err);

--- a/components/preview/PreviewHeader.tsx
+++ b/components/preview/PreviewHeader.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { getPreviewNavigationLinks, getPreviewCtaLink } from './navigation';
 import Logo from '../Logo';
+import { trackEvent } from '../../lib/analytics';
 
 const PREVIEW_BASE = '/preview/verification-readiness';
 
@@ -34,6 +35,7 @@ const PreviewHeader: React.FC = () => {
           className={`inline-flex items-center rounded-md bg-forest-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-forest-800 ${className}`}
           onClick={(e) => {
             setOpen(false);
+            trackEvent('homepage_primary_cta', { location: 'header' });
             e.preventDefault();
             const el = document.getElementById('upload-pdd');
             if (el) {

--- a/components/preview/PreviewHero.tsx
+++ b/components/preview/PreviewHero.tsx
@@ -7,6 +7,7 @@ interface PreviewHeroProps {
   body?: string;
   trustLine?: string;
   primaryCta?: { label: string; href: string };
+  onPrimaryCtaClick?: () => void;
   secondaryCta?: { label: string; href: string };
   children?: React.ReactNode;
 }
@@ -17,6 +18,7 @@ const PreviewHero: React.FC<PreviewHeroProps> = ({
   body,
   trustLine,
   primaryCta,
+  onPrimaryCtaClick,
   secondaryCta,
   children,
 }) => {
@@ -43,6 +45,7 @@ const PreviewHero: React.FC<PreviewHeroProps> = ({
                 {primaryCta && (
                   <Link
                     href={primaryCta.href}
+                    onClick={onPrimaryCtaClick}
                     className="inline-flex items-center justify-center rounded-md bg-forest-700 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-forest-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest-600"
                   >
                     {primaryCta.label}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,20 @@
+import { track } from '@vercel/analytics';
+
+export type AnalyticsEvent =
+  | 'homepage_primary_cta'
+  | 'sample_assessment_view'
+  | 'sample_pdf_download'
+  | 'upload_section_view'
+  | 'upload_file_selected'
+  | 'scope_review_started'
+  | 'scope_review_submitted';
+
+type AnalyticsProperties = Record<string, string | number | boolean | null | undefined>;
+
+export function trackEvent(event: AnalyticsEvent, properties?: AnalyticsProperties): void {
+  try {
+    track(event, properties);
+  } catch {
+    // Analytics must never interrupt the user journey.
+  }
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -11,7 +11,15 @@ export type AnalyticsEvent =
 
 type AnalyticsProperties = Record<string, string | number | boolean | null | undefined>;
 
+const PUBLIC_FUNNEL_ROUTES = new Set(['/', '/sample-assessment', '/how-it-works']);
+
+export function isPublicFunnelRoute(pathname: string): boolean {
+  return PUBLIC_FUNNEL_ROUTES.has(pathname);
+}
+
 export function trackEvent(event: AnalyticsEvent, properties?: AnalyticsProperties): void {
+  if (typeof window === 'undefined' || !isPublicFunnelRoute(window.location.pathname)) return;
+
   try {
     track(event, properties);
   } catch {

--- a/pages/preview/verification-readiness/how-it-works.tsx
+++ b/pages/preview/verification-readiness/how-it-works.tsx
@@ -3,6 +3,7 @@ import SectionHeading from '../../../components/preview/SectionHeading';
 import ProcessStep from '../../../components/preview/ProcessStep';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { trackEvent } from '../../../lib/analytics';
 
 export default function HowItWorksPage() {
   const router = useRouter();
@@ -79,6 +80,7 @@ export default function HowItWorksPage() {
       <section className="mx-auto max-w-6xl px-4 pb-16 md:pb-24 text-center">
         <Link
           href={`${base}#upload-pdd`}
+          onClick={() => trackEvent('homepage_primary_cta', { location: 'mid_page' })}
           className="inline-flex items-center justify-center rounded-md bg-forest-700 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-forest-800"
         >
           Upload your PDD

--- a/pages/preview/verification-readiness/sample-assessment.tsx
+++ b/pages/preview/verification-readiness/sample-assessment.tsx
@@ -4,8 +4,14 @@ import SectionHeading from '../../../components/preview/SectionHeading';
 import ReportPreview from '../../../components/preview/ReportPreview';
 import AssessmentStatusCard from '../../../components/preview/AssessmentStatusCard';
 import DisclaimerPanel from '../../../components/preview/DisclaimerPanel';
+import { useEffect } from 'react';
+import { trackEvent } from '../../../lib/analytics';
 
 export default function SampleAssessmentPage() {
+  useEffect(() => {
+    trackEvent('sample_assessment_view');
+  }, []);
+
   const reportContents = [
     'Executive readiness summary',
     'Priority findings',
@@ -99,6 +105,7 @@ export default function SampleAssessmentPage() {
           target="_blank"
           rel="noopener noreferrer"
           download
+          onClick={() => trackEvent('sample_pdf_download')}
           className="mt-6 inline-flex items-center justify-center rounded-md bg-forest-700 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-forest-800"
         >
           Download Sample Report (PDF)

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import { trackEvent } from '../lib/analytics.ts';
+
+const formSource = fs.readFileSync(new URL('../components/preview/PddUploadForm.tsx', import.meta.url), 'utf8');
+
+test('analytics failures do not interrupt event callers', () => {
+  assert.doesNotThrow(() => trackEvent('upload_file_selected'));
+});
+
+test('public form tracks submission start and success separately', () => {
+  assert.match(formSource, /if \(!isInternal\) trackEvent\('scope_review_started'\)/);
+  assert.match(formSource, /setPhase\('success'\);\s*if \(!isInternal\) trackEvent\('scope_review_submitted'\)/);
+  assert.ok(formSource.indexOf("trackEvent('scope_review_submitted')") > formSource.indexOf("if (!confirmRes.ok)"));
+});
+
+test('file selection tracking sends no file or form data', () => {
+  assert.match(formSource, /trackEvent\('upload_file_selected'\)/);
+  assert.doesNotMatch(formSource, /trackEvent\('upload_file_selected',[\s\S]*?(fileName|name|email|organization|project|methodology)/);
+});

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,12 +1,22 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import test from 'node:test';
-import { trackEvent } from '../lib/analytics.ts';
+import { isPublicFunnelRoute, trackEvent } from '../lib/analytics.ts';
 
 const formSource = fs.readFileSync(new URL('../components/preview/PddUploadForm.tsx', import.meta.url), 'utf8');
 
 test('analytics failures do not interrupt event callers', () => {
   assert.doesNotThrow(() => trackEvent('upload_file_selected'));
+});
+
+test('funnel analytics is limited to production-facing public routes', () => {
+  assert.equal(isPublicFunnelRoute('/'), true);
+  assert.equal(isPublicFunnelRoute('/sample-assessment'), true);
+  assert.equal(isPublicFunnelRoute('/how-it-works'), true);
+  assert.equal(isPublicFunnelRoute('/preview/verification-readiness'), false);
+  assert.equal(isPublicFunnelRoute('/preview/verification-readiness/sample-assessment'), false);
+  assert.equal(isPublicFunnelRoute('/preview/verification-readiness/how-it-works'), false);
+  assert.equal(isPublicFunnelRoute('/sample-assessment/'), false);
 });
 
 test('public form tracks submission start and success separately', () => {


### PR DESCRIPTION
## Summary

Instrument the existing public Article6 sales funnel with Vercel Web Analytics custom events using the installed `@vercel/analytics` 2.0.1 client API. This is observability only.

## Events implemented

- `homepage_primary_cta`: clicks on the existing public Upload your PDD CTAs; metadata is limited to `location` (`hero`, `header`, or `mid_page`). No PII.
- `sample_assessment_view`: once on sample assessment page mount per client page visit. No metadata.
- `sample_pdf_download`: clicks on the existing VM0007 sample PDF link. No metadata; URL and download behavior unchanged.
- `upload_section_view`: first meaningful visibility of the public upload section using `IntersectionObserver`, at most once per page mount. No metadata.
- `upload_file_selected`: after a valid PDF is selected in the public form. No metadata; filename and file contents are excluded.
- `scope_review_started`: after existing validation passes and immediately before the current submission process begins. No metadata.
- `scope_review_submitted`: only after the existing confirmation response succeeds and the success state is set. No metadata; not emitted for validation/upload/confirmation failures.

Analytics failures are caught and cannot block existing user actions. Internal submissions are excluded from public funnel events.

## Privacy and scope

No full name, email, organization, project name, filename, document contents, notes, methodology text, object key, signed URL, or submission reference is sent to analytics.

Intake behavior, submission schema, PDD upload flow, APIs, R2, Quick Check, database persistence, notifications, methodology handling, validation, and existing form requirements are unchanged.

## Validation

- Tests: `npm test` — 41 passed
- Lint: `npm run lint` — passed
- TypeScript: `npx tsc --noEmit` — passed
- `git diff --check` — passed
- Local route smoke check: `/` and `/sample-assessment` returned HTTP 200 and rendered expected content
- Production build compiled analytics-targeted routes, but the repository's existing `/projects` static generation timed out after three 60-second retries
- Browser CLI was unavailable in the environment, so interactive verification used direct local HTTP checks; no real PDD was submitted

Migration required: No.
