### PR TITLE
Add internal sales memory core

### DIFF
--- a/components/InternalHeader.tsx
+++ b/components/InternalHeader.tsx
@@ -11,6 +11,9 @@ export default function InternalHeader() {
           Article6 Internal
         </Link>
         <div className="flex items-center gap-4 text-sm">
+          <Link href="/internal/sales" className="text-gray-600 hover:text-gray-900">
+            Sales
+          </Link>
           <Link href="/internal/submissions" className="text-gray-600 hover:text-gray-900">
             Submissions
           </Link>

--- a/lib/sales-memory.ts
+++ b/lib/sales-memory.ts
@@ -1,0 +1,51 @@
+export const SALES_ORGANIZATION_STATUSES = [
+  "NEW",
+  "CONTACTED",
+  "ENGAGED",
+  "OPPORTUNITY",
+  "NURTURE",
+  "CLOSED_NO",
+  "CLOSED_WON",
+  "DO_NOT_CONTACT",
+] as const;
+
+export type SalesOrganizationStatus = (typeof SALES_ORGANIZATION_STATUSES)[number];
+
+export const SALES_OBJECTION_CODES = [
+  "INTERNAL_TEAM",
+  "ALREADY_COVERED",
+  "VALIDATION_ADVANCED",
+  "NO_BUDGET",
+  "NO_CURRENT_NEED",
+  "WRONG_PERSON",
+  "EXTERNAL_CONSULTANT",
+  "TIMING",
+  "NO_RESPONSE",
+  "OTHER",
+] as const;
+
+export type SalesObjectionCode = (typeof SALES_OBJECTION_CODES)[number];
+
+export function normalizeOrganizationName(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export function normalizeDomain(value: string): string | null {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return null;
+  return trimmed.replace(/^https?:\/\//, "").replace(/^www\./, "").split("/")[0] || null;
+}
+
+export function normalizeOptional(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+export function isSalesOrganizationStatus(value: unknown): value is SalesOrganizationStatus {
+  return typeof value === "string" && SALES_ORGANIZATION_STATUSES.includes(value as SalesOrganizationStatus);
+}
+
+export function isSalesObjectionCode(value: unknown): value is SalesObjectionCode {
+  return typeof value === "string" && SALES_OBJECTION_CODES.includes(value as SalesObjectionCode);
+}

--- a/lib/sales-store.ts
+++ b/lib/sales-store.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from "crypto";
+import { Pool, type QueryResultRow } from "pg";
+import {
+  normalizeDomain,
+  normalizeOrganizationName,
+  type SalesObjectionCode,
+  type SalesOrganizationStatus,
+} from "./sales-memory";
+
+export interface SalesOrganization {
+  id: string;
+  name: string;
+  domain?: string;
+  country?: string;
+  status: SalesOrganizationStatus;
+  objectionCode?: SalesObjectionCode;
+  internalCertificationTeam?: boolean;
+  notes: string;
+  doNotContact: boolean;
+  createdAt: string;
+  updatedAt: string;
+  contactCount?: number;
+  projectCount?: number;
+  lastInteractionAt?: string;
+}
+
+export interface SalesContact {
+  id: string;
+  organizationId: string;
+  name: string;
+  title?: string;
+  email?: string;
+  phone?: string;
+  status: string;
+  notes: string;
+}
+
+export interface SalesProject {
+  id: string;
+  vcsId?: string;
+  name: string;
+  methodology?: string;
+  methodologyVersion?: string;
+  stage?: string;
+  country?: string;
+  vvb?: string;
+  notes: string;
+  role?: string;
+}
+
+export interface SalesInteraction {
+  id: string;
+  organizationId: string;
+  contactId?: string;
+  projectId?: string;
+  contactName?: string;
+  projectName?: string;
+  channel: string;
+  direction: string;
+  interactionType: string;
+  occurredAt: string;
+  subject?: string;
+  summary: string;
+  outcomeCode?: string;
+  externalReference?: string;
+}
+
+export interface SalesOrganizationDetail {
+  organization: SalesOrganization;
+  contacts: SalesContact[];
+  projects: SalesProject[];
+  interactions: SalesInteraction[];
+}
+
+let pool: Pool | undefined;
+function getPool(): Pool {
+  if (pool) return pool;
+  const connectionString = process.env.POSTGRES_URL || process.env.DATABASE_URL;
+  if (!connectionString) throw new Error("Missing POSTGRES_URL or DATABASE_URL environment variable.");
+  pool = new Pool({
+    connectionString,
+    max: 3,
+    ...(process.env.NODE_ENV === "production"
+      ? { ssl: { rejectUnauthorized: true } }
+      : connectionString.includes("localhost")
+        ? { ssl: false }
+        : {}),
+  });
+  return pool;
+}
+
+function iso(value: unknown): string {
+  return new Date(String(value)).toISOString();
+}
+
+function toOrganization(row: QueryResultRow): SalesOrganization {
+  return {
+    id: String(row.id),
+    name: String(row.name),
+    domain: row.domain || undefined,
+    country: row.country || undefined,
+    status: row.status as SalesOrganizationStatus,
+    objectionCode: row.objection_code || undefined,
+    internalCertificationTeam: row.internal_certification_team == null ? undefined : Boolean(row.internal_certification_team),
+    notes: String(row.notes || ""),
+    doNotContact: Boolean(row.do_not_contact),
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+    contactCount: row.contact_count == null ? undefined : Number(row.contact_count),
+    projectCount: row.project_count == null ? undefined : Number(row.project_count),
+    lastInteractionAt: row.last_interaction_at ? iso(row.last_interaction_at) : undefined,
+  };
+}
+
+export async function listSalesOrganizations(search = ""): Promise<SalesOrganization[]> {
+  const q = search.trim();
+  const result = await getPool().query(
+    `SELECT o.*,
+      (SELECT COUNT(*) FROM sales_contacts c WHERE c.organization_id = o.id) AS contact_count,
+      (SELECT COUNT(*) FROM sales_organization_projects op WHERE op.organization_id = o.id) AS project_count,
+      (SELECT MAX(i.occurred_at) FROM sales_interactions i WHERE i.organization_id = o.id) AS last_interaction_at
+     FROM sales_organizations o
+     WHERE $1 = ''
+        OR o.name ILIKE '%' || $1 || '%'
+        OR COALESCE(o.domain, '') ILIKE '%' || $1 || '%'
+        OR EXISTS (SELECT 1 FROM sales_contacts c WHERE c.organization_id = o.id AND (c.name ILIKE '%' || $1 || '%' OR COALESCE(c.email, '') ILIKE '%' || $1 || '%'))
+        OR EXISTS (SELECT 1 FROM sales_organization_projects op JOIN sales_projects p ON p.id = op.project_id WHERE op.organization_id = o.id AND (p.name ILIKE '%' || $1 || '%' OR COALESCE(p.vcs_id, '') ILIKE '%' || $1 || '%' OR COALESCE(p.methodology, '') ILIKE '%' || $1 || '%'))
+     ORDER BY COALESCE((SELECT MAX(i.occurred_at) FROM sales_interactions i WHERE i.organization_id = o.id), o.updated_at) DESC, o.name ASC`,
+    [q]
+  );
+  return result.rows.map(toOrganization);
+}
+
+export async function createSalesOrganization(input: { name: string; domain?: string; country?: string; notes?: string }): Promise<{ organization: SalesOrganization; created: boolean }> {
+  const now = new Date().toISOString();
+  const normalizedName = normalizeOrganizationName(input.name);
+  const domain = normalizeDomain(input.domain || "");
+  const existing = await getPool().query(
+    `SELECT * FROM sales_organizations WHERE normalized_name = $1 OR ($2::text IS NOT NULL AND domain = $2) LIMIT 1`,
+    [normalizedName, domain]
+  );
+  if (existing.rows[0]) return { organization: toOrganization(existing.rows[0]), created: false };
+  const result = await getPool().query(
+    `INSERT INTO sales_organizations (id, name, normalized_name, domain, country, status, notes, do_not_contact, created_at, updated_at)
+     VALUES ($1,$2,$3,$4,$5,'NEW',$6,FALSE,$7,$7) RETURNING *`,
+    [randomUUID(), input.name.trim(), normalizedName, domain, input.country?.trim() || null, input.notes?.trim() || "", now]
+  );
+  return { organization: toOrganization(result.rows[0]), created: true };
+}
+
+export async function addSalesContact(input: { organizationId: string; name: string; title?: string; email?: string; phone?: string; notes?: string }): Promise<SalesContact> {
+  const now = new Date().toISOString();
+  const email = input.email?.trim().toLowerCase() || null;
+  if (email) {
+    const duplicate = await getPool().query("SELECT organization_id FROM sales_contacts WHERE LOWER(email) = $1 LIMIT 1", [email]);
+    if (duplicate.rows[0]) throw new Error(`Contact email already exists on organization ${duplicate.rows[0].organization_id}.`);
+  }
+  const result = await getPool().query(
+    `INSERT INTO sales_contacts (id, organization_id, name, title, email, phone, status, notes, created_at, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,'ACTIVE',$7,$8,$8) RETURNING *`,
+    [randomUUID(), input.organizationId, input.name.trim(), input.title?.trim() || null, email, input.phone?.trim() || null, input.notes?.trim() || "", now]
+  );
+  const row = result.rows[0];
+  return { id: String(row.id), organizationId: String(row.organization_id), name: String(row.name), title: row.title || undefined, email: row.email || undefined, phone: row.phone || undefined, status: String(row.status), notes: String(row.notes || "") };
+}
+
+export async function addSalesProject(input: { organizationId: string; vcsId?: string; name: string; methodology?: string; methodologyVersion?: string; stage?: string; country?: string; vvb?: string; role?: string; notes?: string }): Promise<SalesProject> {
+  const now = new Date().toISOString();
+  const vcsId = input.vcsId?.trim() || null;
+  let projectRow: QueryResultRow | undefined;
+  if (vcsId) {
+    projectRow = (await getPool().query("SELECT * FROM sales_projects WHERE vcs_id = $1 LIMIT 1", [vcsId])).rows[0];
+  }
+  if (!projectRow) {
+    projectRow = (await getPool().query(
+      `INSERT INTO sales_projects (id, vcs_id, name, methodology, methodology_version, stage, country, vvb, notes, created_at, updated_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$10) RETURNING *`,
+      [randomUUID(), vcsId, input.name.trim(), input.methodology?.trim() || null, input.methodologyVersion?.trim() || null, input.stage?.trim() || null, input.country?.trim() || null, input.vvb?.trim() || null, input.notes?.trim() || "", now]
+    )).rows[0];
+  }
+  await getPool().query(
+    `INSERT INTO sales_organization_projects (organization_id, project_id, role, created_at)
+     VALUES ($1,$2,$3,$4) ON CONFLICT (organization_id, project_id) DO UPDATE SET role = EXCLUDED.role`,
+    [input.organizationId, projectRow.id, input.role?.trim() || "OTHER", now]
+  );
+  return { id: String(projectRow.id), vcsId: projectRow.vcs_id || undefined, name: String(projectRow.name), methodology: projectRow.methodology || undefined, methodologyVersion: projectRow.methodology_version || undefined, stage: projectRow.stage || undefined, country: projectRow.country || undefined, vvb: projectRow.vvb || undefined, notes: String(projectRow.notes || ""), role: input.role?.trim() || "OTHER" };
+}
+
+export async function addSalesInteraction(input: { organizationId: string; contactId?: string; projectId?: string; channel: string; direction: string; interactionType: string; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string }): Promise<void> {
+  const createdAt = new Date().toISOString();
+  await getPool().query(
+    `INSERT INTO sales_interactions (id, organization_id, contact_id, project_id, channel, direction, interaction_type, occurred_at, subject, summary, outcome_code, external_reference, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+    [randomUUID(), input.organizationId, input.contactId || null, input.projectId || null, input.channel, input.direction, input.interactionType, input.occurredAt, input.subject?.trim() || null, input.summary.trim(), input.outcomeCode?.trim() || null, input.externalReference?.trim() || null, createdAt]
+  );
+  await getPool().query("UPDATE sales_organizations SET updated_at = $2 WHERE id = $1", [input.organizationId, createdAt]);
+}
+
+export async function updateSalesOrganizationState(input: { organizationId: string; status: SalesOrganizationStatus; objectionCode?: SalesObjectionCode; internalCertificationTeam?: boolean; doNotContact?: boolean; notes?: string }): Promise<void> {
+  await getPool().query(
+    `UPDATE sales_organizations SET status=$2, objection_code=$3, internal_certification_team=$4, do_not_contact=$5, notes=$6, updated_at=$7 WHERE id=$1`,
+    [input.organizationId, input.status, input.objectionCode || null, input.internalCertificationTeam ?? null, Boolean(input.doNotContact), input.notes?.trim() || "", new Date().toISOString()]
+  );
+}
+
+export async function getSalesOrganizationDetail(id: string): Promise<SalesOrganizationDetail | null> {
+  const organizationResult = await getPool().query("SELECT * FROM sales_organizations WHERE id = $1 LIMIT 1", [id]);
+  if (!organizationResult.rows[0]) return null;
+  const [contactsResult, projectsResult, interactionsResult] = await Promise.all([
+    getPool().query("SELECT * FROM sales_contacts WHERE organization_id = $1 ORDER BY name ASC", [id]),
+    getPool().query(`SELECT p.*, op.role FROM sales_organization_projects op JOIN sales_projects p ON p.id = op.project_id WHERE op.organization_id = $1 ORDER BY p.name ASC`, [id]),
+    getPool().query(`SELECT i.*, c.name AS contact_name, p.name AS project_name FROM sales_interactions i LEFT JOIN sales_contacts c ON c.id = i.contact_id LEFT JOIN sales_projects p ON p.id = i.project_id WHERE i.organization_id = $1 ORDER BY i.occurred_at DESC, i.created_at DESC`, [id]),
+  ]);
+  return {
+    organization: toOrganization(organizationResult.rows[0]),
+    contacts: contactsResult.rows.map((row) => ({ id: String(row.id), organizationId: String(row.organization_id), name: String(row.name), title: row.title || undefined, email: row.email || undefined, phone: row.phone || undefined, status: String(row.status), notes: String(row.notes || "") })),
+    projects: projectsResult.rows.map((row) => ({ id: String(row.id), vcsId: row.vcs_id || undefined, name: String(row.name), methodology: row.methodology || undefined, methodologyVersion: row.methodology_version || undefined, stage: row.stage || undefined, country: row.country || undefined, vvb: row.vvb || undefined, notes: String(row.notes || ""), role: String(row.role) })),
+    interactions: interactionsResult.rows.map((row) => ({ id: String(row.id), organizationId: String(row.organization_id), contactId: row.contact_id || undefined, projectId: row.project_id || undefined, contactName: row.contact_name || undefined, projectName: row.project_name || undefined, channel: String(row.channel), direction: String(row.direction), interactionType: String(row.interaction_type), occurredAt: iso(row.occurred_at), subject: row.subject || undefined, summary: String(row.summary), outcomeCode: row.outcome_code || undefined, externalReference: row.external_reference || undefined })),
+  };
+}

--- a/lib/sales-store.ts
+++ b/lib/sales-store.ts
@@ -178,6 +178,7 @@ export async function addSalesProject(input: { organizationId: string; vcsId?: s
       [randomUUID(), vcsId, input.name.trim(), input.methodology?.trim() || null, input.methodologyVersion?.trim() || null, input.stage?.trim() || null, input.country?.trim() || null, input.vvb?.trim() || null, input.notes?.trim() || "", now]
     )).rows[0];
   }
+  if (!projectRow) throw new Error("Project could not be created or resolved.");
   await getPool().query(
     `INSERT INTO sales_organization_projects (organization_id, project_id, role, created_at)
      VALUES ($1,$2,$3,$4) ON CONFLICT (organization_id, project_id) DO UPDATE SET role = EXCLUDED.role`,

--- a/migrations/003_create_sales_memory.sql
+++ b/migrations/003_create_sales_memory.sql
@@ -1,0 +1,85 @@
+CREATE TABLE IF NOT EXISTS sales_organizations (
+  id UUID PRIMARY KEY,
+  name TEXT NOT NULL,
+  normalized_name TEXT NOT NULL,
+  domain TEXT,
+  country TEXT,
+  status VARCHAR(32) NOT NULL DEFAULT 'NEW',
+  objection_code VARCHAR(64),
+  internal_certification_team BOOLEAN,
+  notes TEXT NOT NULL DEFAULT '',
+  do_not_contact BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS sales_organizations_normalized_name_uq
+  ON sales_organizations (normalized_name);
+CREATE UNIQUE INDEX IF NOT EXISTS sales_organizations_domain_uq
+  ON sales_organizations (domain) WHERE domain IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS sales_contacts (
+  id UUID PRIMARY KEY,
+  organization_id UUID NOT NULL REFERENCES sales_organizations(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  title TEXT,
+  email TEXT,
+  phone TEXT,
+  status VARCHAR(32) NOT NULL DEFAULT 'ACTIVE',
+  notes TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS sales_contacts_email_uq
+  ON sales_contacts (LOWER(email)) WHERE email IS NOT NULL;
+CREATE INDEX IF NOT EXISTS sales_contacts_organization_idx
+  ON sales_contacts (organization_id);
+
+CREATE TABLE IF NOT EXISTS sales_projects (
+  id UUID PRIMARY KEY,
+  vcs_id TEXT,
+  name TEXT NOT NULL,
+  methodology TEXT,
+  methodology_version TEXT,
+  stage TEXT,
+  country TEXT,
+  vvb TEXT,
+  notes TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS sales_projects_vcs_id_uq
+  ON sales_projects (vcs_id) WHERE vcs_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS sales_organization_projects (
+  organization_id UUID NOT NULL REFERENCES sales_organizations(id) ON DELETE CASCADE,
+  project_id UUID NOT NULL REFERENCES sales_projects(id) ON DELETE CASCADE,
+  role VARCHAR(64) NOT NULL DEFAULT 'OTHER',
+  created_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (organization_id, project_id)
+);
+
+CREATE TABLE IF NOT EXISTS sales_interactions (
+  id UUID PRIMARY KEY,
+  organization_id UUID NOT NULL REFERENCES sales_organizations(id) ON DELETE CASCADE,
+  contact_id UUID REFERENCES sales_contacts(id) ON DELETE SET NULL,
+  project_id UUID REFERENCES sales_projects(id) ON DELETE SET NULL,
+  channel VARCHAR(32) NOT NULL,
+  direction VARCHAR(16) NOT NULL,
+  interaction_type VARCHAR(32) NOT NULL,
+  occurred_at TIMESTAMPTZ NOT NULL,
+  subject TEXT,
+  summary TEXT NOT NULL,
+  outcome_code VARCHAR(64),
+  external_reference TEXT,
+  created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS sales_interactions_organization_occurred_idx
+  ON sales_interactions (organization_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS sales_interactions_contact_idx
+  ON sales_interactions (contact_id) WHERE contact_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS sales_interactions_project_idx
+  ON sales_interactions (project_id) WHERE project_id IS NOT NULL;

--- a/pages/api/internal/sales.ts
+++ b/pages/api/internal/sales.ts
@@ -1,0 +1,97 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { hasInternalUploadSession } from "../../../lib/internal-auth";
+import {
+  addSalesContact,
+  addSalesInteraction,
+  addSalesProject,
+  createSalesOrganization,
+  updateSalesOrganizationState,
+} from "../../../lib/sales-store";
+import { isSalesObjectionCode, isSalesOrganizationStatus, normalizeOptional } from "../../../lib/sales-memory";
+
+function value(body: NextApiRequest["body"], key: string): string {
+  const candidate = body?.[key];
+  return typeof candidate === "string" ? candidate.trim() : "";
+}
+
+function organizationRedirect(res: NextApiResponse, id: string, params?: Record<string, string>) {
+  const query = params ? `?${new URLSearchParams(params).toString()}` : "";
+  res.redirect(303, `/internal/sales/organizations/${encodeURIComponent(id)}${query}`);
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!(await hasInternalUploadSession(req))) return res.status(401).json({ error: "Internal session required." });
+  if (req.method !== "POST") return res.status(405).setHeader("Allow", "POST").json({ error: "Method not allowed." });
+
+  const action = value(req.body, "action");
+  const organizationId = value(req.body, "organizationId");
+
+  try {
+    if (action === "create_organization") {
+      const name = value(req.body, "name");
+      if (!name) return res.status(400).json({ error: "Organization name is required." });
+      const result = await createSalesOrganization({ name, domain: value(req.body, "domain"), country: value(req.body, "country"), notes: value(req.body, "notes") });
+      return organizationRedirect(res, result.organization.id, result.created ? undefined : { duplicate: "1" });
+    }
+
+    if (!organizationId) return res.status(400).json({ error: "Organization id is required." });
+
+    if (action === "add_contact") {
+      const name = value(req.body, "name");
+      if (!name) return res.status(400).json({ error: "Contact name is required." });
+      await addSalesContact({ organizationId, name, title: value(req.body, "title"), email: value(req.body, "email"), phone: value(req.body, "phone"), notes: value(req.body, "notes") });
+      return organizationRedirect(res, organizationId);
+    }
+
+    if (action === "add_project") {
+      const name = value(req.body, "name");
+      if (!name) return res.status(400).json({ error: "Project name is required." });
+      await addSalesProject({ organizationId, name, vcsId: value(req.body, "vcsId"), methodology: value(req.body, "methodology"), methodologyVersion: value(req.body, "methodologyVersion"), stage: value(req.body, "stage"), country: value(req.body, "country"), vvb: value(req.body, "vvb"), role: value(req.body, "role"), notes: value(req.body, "notes") });
+      return organizationRedirect(res, organizationId);
+    }
+
+    if (action === "add_interaction") {
+      const summary = value(req.body, "summary");
+      const occurredAt = value(req.body, "occurredAt");
+      if (!summary || !occurredAt) return res.status(400).json({ error: "Interaction date and summary are required." });
+      const parsedDate = new Date(occurredAt);
+      if (Number.isNaN(parsedDate.getTime())) return res.status(400).json({ error: "Interaction date is invalid." });
+      await addSalesInteraction({
+        organizationId,
+        contactId: normalizeOptional(req.body?.contactId) || undefined,
+        projectId: normalizeOptional(req.body?.projectId) || undefined,
+        channel: value(req.body, "channel") || "OTHER",
+        direction: value(req.body, "direction") || "INTERNAL",
+        interactionType: value(req.body, "interactionType") || "NOTE",
+        occurredAt: parsedDate.toISOString(),
+        subject: value(req.body, "subject"),
+        summary,
+        outcomeCode: value(req.body, "outcomeCode"),
+      });
+      return organizationRedirect(res, organizationId);
+    }
+
+    if (action === "update_status") {
+      const status = value(req.body, "status");
+      const objection = value(req.body, "objectionCode");
+      if (!isSalesOrganizationStatus(status)) return res.status(400).json({ error: "Invalid organization status." });
+      if (objection && !isSalesObjectionCode(objection)) return res.status(400).json({ error: "Invalid objection code." });
+      const internalTeamValue = value(req.body, "internalCertificationTeam");
+      await updateSalesOrganizationState({
+        organizationId,
+        status,
+        objectionCode: objection || undefined,
+        internalCertificationTeam: internalTeamValue === "" ? undefined : internalTeamValue === "true",
+        doNotContact: req.body?.doNotContact === "on",
+        notes: value(req.body, "notes"),
+      });
+      return organizationRedirect(res, organizationId);
+    }
+
+    return res.status(400).json({ error: "Unknown sales action." });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Sales memory update failed.";
+    if (organizationId) return organizationRedirect(res, organizationId, { error: message.slice(0, 180) });
+    return res.status(500).json({ error: message });
+  }
+}

--- a/pages/api/internal/sales.ts
+++ b/pages/api/internal/sales.ts
@@ -75,12 +75,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const status = value(req.body, "status");
       const objection = value(req.body, "objectionCode");
       if (!isSalesOrganizationStatus(status)) return res.status(400).json({ error: "Invalid organization status." });
-      if (objection && !isSalesObjectionCode(objection)) return res.status(400).json({ error: "Invalid objection code." });
+      const objectionCode = objection && isSalesObjectionCode(objection) ? objection : undefined;
+      if (objection && !objectionCode) return res.status(400).json({ error: "Invalid objection code." });
       const internalTeamValue = value(req.body, "internalCertificationTeam");
       await updateSalesOrganizationState({
         organizationId,
         status,
-        objectionCode: objection || undefined,
+        objectionCode,
         internalCertificationTeam: internalTeamValue === "" ? undefined : internalTeamValue === "true",
         doNotContact: req.body?.doNotContact === "on",
         notes: value(req.body, "notes"),

--- a/pages/internal/sales/index.tsx
+++ b/pages/internal/sales/index.tsx
@@ -1,0 +1,67 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { listSalesOrganizations, type SalesOrganization } from "../../../lib/sales-store";
+
+interface Props { organizations: SalesOrganization[]; search: string; }
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ query }) => {
+  const search = typeof query.q === "string" ? query.q : "";
+  return { props: { organizations: await listSalesOrganizations(search), search } };
+};
+
+function formatDate(value?: string) {
+  return value ? new Date(value).toLocaleString() : "Never";
+}
+
+function statusClass(status: string) {
+  if (status === "DO_NOT_CONTACT" || status === "CLOSED_NO") return "bg-red-50 text-red-700";
+  if (status === "OPPORTUNITY" || status === "CLOSED_WON") return "bg-green-50 text-green-700";
+  if (status === "NURTURE") return "bg-amber-50 text-amber-700";
+  return "bg-gray-100 text-gray-700";
+}
+
+export default function SalesIndexPage({ organizations, search }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return <>
+    <Head><title>Sales Memory | Article6 Internal</title><meta name="robots" content="noindex,nofollow" /></Head>
+    <main className="min-h-screen bg-gray-50 px-4 py-10 text-gray-900"><div className="mx-auto max-w-6xl">
+      <p className="text-sm font-semibold uppercase tracking-wide text-forest-700">Article6 internal tool</p>
+      <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
+        <div><h1 className="text-2xl font-bold tracking-tight">Sales memory</h1><p className="mt-2 text-sm text-gray-600">Organization-first relationship history. Search before contacting anyone.</p></div>
+      </div>
+
+      <form method="get" className="mt-6 flex gap-2">
+        <input name="q" defaultValue={search} placeholder="Search organization, contact, email, VCS ID, project, methodology…" className="min-w-0 flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm" />
+        <button className="rounded-md bg-forest-700 px-4 py-2 text-sm font-medium text-white hover:bg-forest-800">Search</button>
+        {search ? <Link href="/internal/sales" className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700">Clear</Link> : null}
+      </form>
+
+      <section className="mt-8 rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="text-base font-semibold">Add organization</h2>
+        <form method="post" action="/api/internal/sales" className="mt-4 grid gap-3 md:grid-cols-4">
+          <input type="hidden" name="action" value="create_organization" />
+          <input required name="name" placeholder="Organization name" className="rounded-md border border-gray-300 px-3 py-2 text-sm" />
+          <input name="domain" placeholder="Domain, e.g. terraformation.com" className="rounded-md border border-gray-300 px-3 py-2 text-sm" />
+          <input name="country" placeholder="Country" className="rounded-md border border-gray-300 px-3 py-2 text-sm" />
+          <button className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white">Add organization</button>
+        </form>
+        <p className="mt-2 text-xs text-gray-500">Existing normalized names or domains resolve to the existing organization instead of creating duplicates.</p>
+      </section>
+
+      <div className="mt-8 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+        {organizations.length === 0 ? <p className="p-6 text-sm text-gray-600">No organizations found.</p> : <div className="overflow-x-auto"><table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+          <thead className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500"><tr>
+            <th className="px-5 py-3">Organization</th><th className="px-5 py-3">Status</th><th className="px-5 py-3">Projects</th><th className="px-5 py-3">Contacts</th><th className="px-5 py-3">Key objection</th><th className="px-5 py-3">Last interaction</th><th className="px-5 py-3">Action</th>
+          </tr></thead>
+          <tbody className="divide-y divide-gray-100">{organizations.map((organization) => <tr key={organization.id} className={organization.doNotContact ? "bg-red-50/50" : ""}>
+            <td className="px-5 py-4"><div className="font-medium text-gray-900">{organization.name}</div><div className="text-xs text-gray-500">{organization.domain || "No domain"}</div></td>
+            <td className="px-5 py-4"><span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${statusClass(organization.status)}`}>{organization.status}</span>{organization.doNotContact ? <div className="mt-1 text-xs font-semibold text-red-700">DO NOT CONTACT</div> : null}</td>
+            <td className="px-5 py-4">{organization.projectCount || 0}</td><td className="px-5 py-4">{organization.contactCount || 0}</td>
+            <td className="px-5 py-4">{organization.objectionCode || "—"}</td><td className="whitespace-nowrap px-5 py-4">{formatDate(organization.lastInteractionAt)}</td>
+            <td className="px-5 py-4"><Link href={`/internal/sales/organizations/${organization.id}`} className="font-medium text-forest-700 hover:text-forest-800">Open</Link></td>
+          </tr>)}</tbody>
+        </table></div>}
+      </div>
+    </div></main>
+  </>;
+}

--- a/pages/internal/sales/organizations/[id].tsx
+++ b/pages/internal/sales/organizations/[id].tsx
@@ -1,0 +1,75 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { getSalesOrganizationDetail, type SalesOrganizationDetail } from "../../../../lib/sales-store";
+import { SALES_OBJECTION_CODES, SALES_ORGANIZATION_STATUSES } from "../../../../lib/sales-memory";
+
+interface Props { detail: SalesOrganizationDetail; duplicate: boolean; error?: string; }
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ params, query }) => {
+  const id = typeof params?.id === "string" ? params.id : "";
+  const detail = await getSalesOrganizationDetail(id);
+  if (!detail) return { notFound: true };
+  return { props: { detail, duplicate: query.duplicate === "1", error: typeof query.error === "string" ? query.error : undefined } };
+};
+
+const fieldClass = "rounded-md border border-gray-300 px-3 py-2 text-sm";
+
+export default function OrganizationPage({ detail, duplicate, error }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { organization, contacts, projects, interactions } = detail;
+  return <>
+    <Head><title>{organization.name} | Sales Memory</title><meta name="robots" content="noindex,nofollow" /></Head>
+    <main className="min-h-screen bg-gray-50 px-4 py-10 text-gray-900"><div className="mx-auto max-w-6xl">
+      <Link href="/internal/sales" className="text-sm font-medium text-forest-700">← Sales memory</Link>
+      <div className="mt-4 flex flex-wrap items-start justify-between gap-4">
+        <div><h1 className="text-3xl font-bold tracking-tight">{organization.name}</h1><p className="mt-1 text-sm text-gray-600">{organization.domain || "No domain recorded"}{organization.country ? ` · ${organization.country}` : ""}</p></div>
+        <div className="text-right"><div className="text-sm font-semibold">{organization.status}</div>{organization.doNotContact ? <div className="mt-1 rounded bg-red-100 px-2 py-1 text-xs font-bold text-red-700">DO NOT CONTACT</div> : null}</div>
+      </div>
+      {duplicate ? <div className="mt-5 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">Duplicate prevented. This existing organization matched the name or domain you entered.</div> : null}
+      {error ? <div className="mt-5 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">{error}</div> : null}
+
+      <section className="mt-8 rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="font-semibold">Current disposition</h2>
+        <form method="post" action="/api/internal/sales" className="mt-4 grid gap-3 md:grid-cols-3">
+          <input type="hidden" name="action" value="update_status" /><input type="hidden" name="organizationId" value={organization.id} />
+          <select name="status" defaultValue={organization.status} className={fieldClass}>{SALES_ORGANIZATION_STATUSES.map((value) => <option key={value}>{value}</option>)}</select>
+          <select name="objectionCode" defaultValue={organization.objectionCode || ""} className={fieldClass}><option value="">No objection</option>{SALES_OBJECTION_CODES.map((value) => <option key={value}>{value}</option>)}</select>
+          <select name="internalCertificationTeam" defaultValue={organization.internalCertificationTeam == null ? "" : String(organization.internalCertificationTeam)} className={fieldClass}><option value="">Internal team unknown</option><option value="true">Internal team: yes</option><option value="false">Internal team: no</option></select>
+          <textarea name="notes" defaultValue={organization.notes} placeholder="Organization notes" className={`${fieldClass} md:col-span-2`} />
+          <label className="flex items-center gap-2 text-sm"><input type="checkbox" name="doNotContact" defaultChecked={organization.doNotContact} /> Do not contact</label>
+          <button className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white md:col-span-3">Update disposition</button>
+        </form>
+      </section>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><h2 className="font-semibold">Contacts</h2>
+          <div className="mt-3 space-y-3">{contacts.length ? contacts.map((contact) => <div key={contact.id} className="rounded-md border border-gray-100 p-3 text-sm"><div className="font-medium">{contact.name}</div><div className="text-gray-600">{contact.title || "No title"}</div><div className="mt-1 text-xs text-gray-500">{contact.email || contact.phone || "No contact details"}</div></div>) : <p className="text-sm text-gray-500">No contacts yet.</p>}</div>
+          <form method="post" action="/api/internal/sales" className="mt-4 grid gap-2"><input type="hidden" name="action" value="add_contact" /><input type="hidden" name="organizationId" value={organization.id} /><input required name="name" placeholder="Name" className={fieldClass} /><input name="title" placeholder="Title" className={fieldClass} /><input name="email" type="email" placeholder="Email" className={fieldClass} /><input name="phone" placeholder="Phone" className={fieldClass} /><button className="rounded-md bg-forest-700 px-4 py-2 text-sm font-medium text-white">Add contact</button></form>
+        </section>
+
+        <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><h2 className="font-semibold">Projects</h2>
+          <div className="mt-3 space-y-3">{projects.length ? projects.map((project) => <div key={project.id} className="rounded-md border border-gray-100 p-3 text-sm"><div className="font-medium">{project.name}</div><div className="text-gray-600">{project.vcsId ? `VCS ${project.vcsId}` : "No VCS ID"}{project.methodology ? ` · ${project.methodology}${project.methodologyVersion ? ` ${project.methodologyVersion}` : ""}` : ""}</div><div className="mt-1 text-xs text-gray-500">Role: {project.role || "OTHER"}{project.vvb ? ` · VVB: ${project.vvb}` : ""}</div></div>) : <p className="text-sm text-gray-500">No projects yet.</p>}</div>
+          <form method="post" action="/api/internal/sales" className="mt-4 grid gap-2"><input type="hidden" name="action" value="add_project" /><input type="hidden" name="organizationId" value={organization.id} /><input required name="name" placeholder="Project name" className={fieldClass} /><input name="vcsId" placeholder="VCS ID" className={fieldClass} /><div className="grid grid-cols-2 gap-2"><input name="methodology" placeholder="Methodology" className={fieldClass} /><input name="methodologyVersion" placeholder="Version" className={fieldClass} /></div><input name="vvb" placeholder="VVB" className={fieldClass} /><input name="role" placeholder="Organization role" className={fieldClass} /><button className="rounded-md bg-forest-700 px-4 py-2 text-sm font-medium text-white">Add / link project</button></form>
+        </section>
+      </div>
+
+      <section className="mt-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><h2 className="font-semibold">Log interaction</h2>
+        <form method="post" action="/api/internal/sales" className="mt-4 grid gap-3 md:grid-cols-3"><input type="hidden" name="action" value="add_interaction" /><input type="hidden" name="organizationId" value={organization.id} />
+          <select name="contactId" className={fieldClass}><option value="">No contact</option>{contacts.map((contact) => <option value={contact.id} key={contact.id}>{contact.name}</option>)}</select>
+          <select name="projectId" className={fieldClass}><option value="">No project</option>{projects.map((project) => <option value={project.id} key={project.id}>{project.name}</option>)}</select>
+          <input name="occurredAt" type="datetime-local" required className={fieldClass} />
+          <select name="channel" className={fieldClass}><option>EMAIL</option><option>WHATSAPP</option><option>PHONE</option><option>MEETING</option><option>LINKEDIN</option><option>OTHER</option></select>
+          <select name="direction" className={fieldClass}><option>OUTBOUND</option><option>INBOUND</option><option>INTERNAL</option></select>
+          <select name="interactionType" className={fieldClass}><option>MESSAGE</option><option>REPLY</option><option>CALL</option><option>MEETING</option><option>NOTE</option><option>REFERRAL</option></select>
+          <input name="subject" placeholder="Subject / short label" className={`${fieldClass} md:col-span-2`} /><input name="outcomeCode" placeholder="Outcome code" className={fieldClass} />
+          <textarea required name="summary" placeholder="What happened? Keep this factual." className={`${fieldClass} md:col-span-3`} />
+          <button className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white md:col-span-3">Log interaction</button>
+        </form>
+      </section>
+
+      <section className="mt-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><h2 className="font-semibold">Interaction timeline</h2>
+        <div className="mt-4 space-y-4">{interactions.length ? interactions.map((interaction) => <article key={interaction.id} className="border-l-2 border-gray-200 pl-4"><div className="flex flex-wrap items-center gap-2 text-xs text-gray-500"><span>{new Date(interaction.occurredAt).toLocaleString()}</span><span>{interaction.direction} · {interaction.channel} · {interaction.interactionType}</span>{interaction.outcomeCode ? <span className="rounded bg-gray-100 px-2 py-0.5 font-medium text-gray-700">{interaction.outcomeCode}</span> : null}</div><div className="mt-1 text-sm font-medium text-gray-900">{interaction.subject || interaction.contactName || "Interaction"}</div><p className="mt-1 whitespace-pre-wrap text-sm text-gray-700">{interaction.summary}</p><div className="mt-1 text-xs text-gray-500">{[interaction.contactName, interaction.projectName].filter(Boolean).join(" · ")}</div></article>) : <p className="text-sm text-gray-500">No interactions yet.</p>}</div>
+      </section>
+    </div></main>
+  </>;
+}

--- a/tests/sales-memory.test.ts
+++ b/tests/sales-memory.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isSalesObjectionCode,
+  isSalesOrganizationStatus,
+  normalizeDomain,
+  normalizeOrganizationName,
+} from "../lib/sales-memory";
+
+test("normalizes organization names for duplicate detection", () => {
+  assert.equal(normalizeOrganizationName("  Terraformation   Inc  "), "terraformation inc");
+});
+
+test("normalizes domains consistently", () => {
+  assert.equal(normalizeDomain("https://www.Terraformation.com/projects"), "terraformation.com");
+  assert.equal(normalizeDomain("  terraformation.com  "), "terraformation.com");
+  assert.equal(normalizeDomain(""), null);
+});
+
+test("accepts only known organization statuses", () => {
+  assert.equal(isSalesOrganizationStatus("NURTURE"), true);
+  assert.equal(isSalesOrganizationStatus("REJECTED_FOREVER"), false);
+});
+
+test("accepts only known objection codes", () => {
+  assert.equal(isSalesObjectionCode("INTERNAL_TEAM"), true);
+  assert.equal(isSalesObjectionCode("SOMETHING_ELSE"), false);
+});


### PR DESCRIPTION
## What changed

Adds the first Article6 internal sales-memory layer centered on organizations rather than tasks.

- adds PostgreSQL schema for organizations, contacts, projects, organization-project roles, and append-only interactions
- adds `/internal/sales` organization search and create flow
- adds organization detail pages with contacts, projects, disposition/objection state, and chronological interaction history
- adds protected internal mutation endpoint using the existing signed internal-session cookie
- prevents duplicate organizations by normalized name or domain and duplicate contacts by email
- adds Sales to the existing internal navigation
- adds focused normalization/status tests

## Why

Sales history is now spread across Gmail, project lists, memory, and Trello. The immediate operational risk is contacting an organization without seeing prior rejections, referrals, or existing relationships. This PR establishes the source-of-truth data model and UI that later Gmail/list backfills will populate.

## Scope

This PR does **not** import Gmail, automate classification, send email, or modify submission/intake behavior. Those remain separate follow-up PRs.

## Migration

Required: `migrations/003_create_sales_memory.sql`

## Validation

The change follows the repo's existing Pages Router, `pg`, SQL migration, and internal-session patterns. Runtime CI/preview checks are pending on the draft PR.