### PR TITLE
Add Gmail sales-history verification queue

### DIFF
--- a/lib/sales-import-store.ts
+++ b/lib/sales-import-store.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from "crypto";
+import { Pool, type PoolClient, type QueryResultRow } from "pg";
+import { normalizeDomain, normalizeOrganizationName, isSalesObjectionCode, isSalesOrganizationStatus } from "./sales-memory";
+
+export interface SalesImportContact { name: string; title?: string; email?: string; phone?: string; notes?: string; }
+export interface SalesImportProject { vcsId?: string; name: string; methodology?: string; methodologyVersion?: string; stage?: string; country?: string; vvb?: string; role?: string; notes?: string; }
+export interface SalesImportInteraction { contactEmail?: string; projectVcsId?: string; channel?: string; direction?: string; interactionType?: string; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string; }
+
+export interface SalesImportCandidate {
+  id: string;
+  sourceType: string;
+  sourceKey: string;
+  organizationName: string;
+  domain?: string;
+  proposedStatus?: string;
+  proposedObjection?: string;
+  confidence?: number;
+  contacts: SalesImportContact[];
+  projects: SalesImportProject[];
+  interactions: SalesImportInteraction[];
+  evidenceSummary: string;
+  matchedOrganizationId?: string;
+  matchedOrganizationName?: string;
+  state: string;
+  createdAt: string;
+  reviewedAt?: string;
+}
+
+let pool: Pool | undefined;
+function getPool(): Pool {
+  if (pool) return pool;
+  const connectionString = process.env.POSTGRES_URL || process.env.DATABASE_URL;
+  if (!connectionString) throw new Error("Missing POSTGRES_URL or DATABASE_URL environment variable.");
+  pool = new Pool({
+    connectionString,
+    max: 3,
+    ...(process.env.NODE_ENV === "production" ? { ssl: { rejectUnauthorized: true } } : connectionString.includes("localhost") ? { ssl: false } : {}),
+  });
+  return pool;
+}
+
+function toCandidate(row: QueryResultRow): SalesImportCandidate {
+  return {
+    id: String(row.id), sourceType: String(row.source_type), sourceKey: String(row.source_key), organizationName: String(row.organization_name),
+    domain: row.domain || undefined, proposedStatus: row.proposed_status || undefined, proposedObjection: row.proposed_objection || undefined,
+    confidence: row.confidence == null ? undefined : Number(row.confidence), contacts: Array.isArray(row.contacts_json) ? row.contacts_json : [],
+    projects: Array.isArray(row.projects_json) ? row.projects_json : [], interactions: Array.isArray(row.interactions_json) ? row.interactions_json : [],
+    evidenceSummary: String(row.evidence_summary || ""), matchedOrganizationId: row.matched_organization_id || undefined,
+    matchedOrganizationName: row.matched_organization_name || undefined, state: String(row.state),
+    createdAt: new Date(row.created_at).toISOString(), reviewedAt: row.reviewed_at ? new Date(row.reviewed_at).toISOString() : undefined,
+  };
+}
+
+export async function listSalesImportCandidates(state = "PENDING"): Promise<SalesImportCandidate[]> {
+  const result = await getPool().query(
+    `SELECT c.*, o.name AS matched_organization_name
+     FROM sales_import_candidates c
+     LEFT JOIN sales_organizations o ON o.id = c.matched_organization_id
+     WHERE c.state = $1
+     ORDER BY c.confidence DESC NULLS LAST, c.created_at DESC`, [state]
+  );
+  return result.rows.map(toCandidate);
+}
+
+export async function createSalesImportCandidate(input: Omit<SalesImportCandidate, "id" | "state" | "createdAt" | "reviewedAt" | "matchedOrganizationName">): Promise<SalesImportCandidate> {
+  const domain = normalizeDomain(input.domain || "");
+  const normalizedName = normalizeOrganizationName(input.organizationName);
+  const match = await getPool().query(
+    `SELECT o.id FROM sales_organizations o
+     WHERE o.normalized_name = $1 OR ($2::text IS NOT NULL AND o.domain = $2)
+        OR EXISTS (SELECT 1 FROM sales_contacts sc WHERE sc.organization_id = o.id AND LOWER(sc.email) = ANY($3::text[]))
+     LIMIT 1`,
+    [normalizedName, domain, input.contacts.map((c) => c.email?.trim().toLowerCase()).filter(Boolean)]
+  );
+  const now = new Date().toISOString();
+  const result = await getPool().query(
+    `INSERT INTO sales_import_candidates
+      (id, source_type, source_key, organization_name, domain, proposed_status, proposed_objection, confidence, contacts_json, projects_json, interactions_json, evidence_summary, matched_organization_id, state, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10::jsonb,$11::jsonb,$12,$13,'PENDING',$14)
+     ON CONFLICT (source_type, source_key) DO UPDATE SET
+       organization_name=EXCLUDED.organization_name, domain=EXCLUDED.domain, proposed_status=EXCLUDED.proposed_status,
+       proposed_objection=EXCLUDED.proposed_objection, confidence=EXCLUDED.confidence, contacts_json=EXCLUDED.contacts_json,
+       projects_json=EXCLUDED.projects_json, interactions_json=EXCLUDED.interactions_json, evidence_summary=EXCLUDED.evidence_summary,
+       matched_organization_id=EXCLUDED.matched_organization_id
+     RETURNING *`,
+    [randomUUID(), input.sourceType, input.sourceKey, input.organizationName.trim(), domain, input.proposedStatus || null, input.proposedObjection || null,
+      input.confidence ?? null, JSON.stringify(input.contacts), JSON.stringify(input.projects), JSON.stringify(input.interactions), input.evidenceSummary || "", match.rows[0]?.id || input.matchedOrganizationId || null, now]
+  );
+  return toCandidate(result.rows[0]);
+}
+
+async function resolveOrganization(client: PoolClient, candidate: QueryResultRow, explicitOrganizationId?: string): Promise<string> {
+  if (explicitOrganizationId) {
+    const explicit = await client.query("SELECT id FROM sales_organizations WHERE id=$1", [explicitOrganizationId]);
+    if (!explicit.rows[0]) throw new Error("Selected organization does not exist.");
+    return String(explicit.rows[0].id);
+  }
+  if (candidate.matched_organization_id) return String(candidate.matched_organization_id);
+  const domain = normalizeDomain(candidate.domain || "");
+  const normalizedName = normalizeOrganizationName(String(candidate.organization_name));
+  const existing = await client.query("SELECT id FROM sales_organizations WHERE normalized_name=$1 OR ($2::text IS NOT NULL AND domain=$2) LIMIT 1", [normalizedName, domain]);
+  if (existing.rows[0]) return String(existing.rows[0].id);
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  await client.query(
+    `INSERT INTO sales_organizations (id,name,normalized_name,domain,status,notes,do_not_contact,created_at,updated_at)
+     VALUES ($1,$2,$3,$4,'NEW','',FALSE,$5,$5)`, [id, candidate.organization_name, normalizedName, domain, now]
+  );
+  return id;
+}
+
+export async function approveSalesImportCandidate(id: string, explicitOrganizationId?: string): Promise<string> {
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    const result = await client.query("SELECT * FROM sales_import_candidates WHERE id=$1 FOR UPDATE", [id]);
+    const candidate = result.rows[0];
+    if (!candidate) throw new Error("Import candidate not found.");
+    if (candidate.state !== "PENDING") throw new Error("Import candidate has already been reviewed.");
+    const organizationId = await resolveOrganization(client, candidate, explicitOrganizationId);
+    const now = new Date().toISOString();
+    const contactIds = new Map<string, string>();
+    for (const contact of (candidate.contacts_json || []) as SalesImportContact[]) {
+      const email = contact.email?.trim().toLowerCase() || null;
+      let row = email ? (await client.query("SELECT * FROM sales_contacts WHERE LOWER(email)=$1 LIMIT 1", [email])).rows[0] : undefined;
+      if (row && String(row.organization_id) !== organizationId) throw new Error(`Contact ${email} already belongs to another organization.`);
+      if (!row) {
+        const contactId = randomUUID();
+        const inserted = await client.query(
+          `INSERT INTO sales_contacts (id,organization_id,name,title,email,phone,status,notes,created_at,updated_at)
+           VALUES ($1,$2,$3,$4,$5,$6,'ACTIVE',$7,$8,$8) RETURNING *`,
+          [contactId, organizationId, contact.name.trim(), contact.title?.trim() || null, email, contact.phone?.trim() || null, contact.notes?.trim() || "", now]
+        );
+        row = inserted.rows[0];
+      }
+      if (email) contactIds.set(email, String(row.id));
+    }
+    const projectIds = new Map<string, string>();
+    for (const project of (candidate.projects_json || []) as SalesImportProject[]) {
+      const vcsId = project.vcsId?.trim() || null;
+      let row = vcsId ? (await client.query("SELECT * FROM sales_projects WHERE vcs_id=$1 LIMIT 1", [vcsId])).rows[0] : undefined;
+      if (!row) {
+        const projectId = randomUUID();
+        row = (await client.query(
+          `INSERT INTO sales_projects (id,vcs_id,name,methodology,methodology_version,stage,country,vvb,notes,created_at,updated_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$10) RETURNING *`,
+          [projectId, vcsId, project.name.trim(), project.methodology?.trim() || null, project.methodologyVersion?.trim() || null, project.stage?.trim() || null,
+            project.country?.trim() || null, project.vvb?.trim() || null, project.notes?.trim() || "", now]
+        )).rows[0];
+      }
+      await client.query(
+        `INSERT INTO sales_organization_projects (organization_id,project_id,role,created_at)
+         VALUES ($1,$2,$3,$4) ON CONFLICT (organization_id,project_id) DO UPDATE SET role=EXCLUDED.role`,
+        [organizationId, row.id, project.role?.trim() || "OTHER", now]
+      );
+      if (vcsId) projectIds.set(vcsId, String(row.id));
+    }
+    for (const interaction of (candidate.interactions_json || []) as SalesImportInteraction[]) {
+      const parsed = new Date(interaction.occurredAt);
+      if (Number.isNaN(parsed.getTime())) throw new Error("Candidate contains an invalid interaction date.");
+      await client.query(
+        `INSERT INTO sales_interactions (id,organization_id,contact_id,project_id,channel,direction,interaction_type,occurred_at,subject,summary,outcome_code,external_reference,created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+        [randomUUID(), organizationId, interaction.contactEmail ? contactIds.get(interaction.contactEmail.trim().toLowerCase()) || null : null,
+          interaction.projectVcsId ? projectIds.get(interaction.projectVcsId.trim()) || null : null, interaction.channel || "EMAIL", interaction.direction || "INTERNAL",
+          interaction.interactionType || "MESSAGE", parsed.toISOString(), interaction.subject?.trim() || null, interaction.summary.trim(), interaction.outcomeCode?.trim() || null,
+          interaction.externalReference?.trim() || null, now]
+      );
+    }
+    if (candidate.proposed_status && isSalesOrganizationStatus(candidate.proposed_status)) {
+      const objection = candidate.proposed_objection && isSalesObjectionCode(candidate.proposed_objection) ? candidate.proposed_objection : null;
+      await client.query("UPDATE sales_organizations SET status=$2, objection_code=$3, updated_at=$4 WHERE id=$1", [organizationId, candidate.proposed_status, objection, now]);
+    } else {
+      await client.query("UPDATE sales_organizations SET updated_at=$2 WHERE id=$1", [organizationId, now]);
+    }
+    await client.query("UPDATE sales_import_candidates SET state='APPROVED', matched_organization_id=$2, reviewed_at=$3 WHERE id=$1", [id, organizationId, now]);
+    await client.query("COMMIT");
+    return organizationId;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function ignoreSalesImportCandidate(id: string): Promise<void> {
+  await getPool().query("UPDATE sales_import_candidates SET state='IGNORED', reviewed_at=$2 WHERE id=$1 AND state='PENDING'", [id, new Date().toISOString()]);
+}

--- a/migrations/004_create_sales_import_candidates.sql
+++ b/migrations/004_create_sales_import_candidates.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS sales_import_candidates (
+  id UUID PRIMARY KEY,
+  source_type VARCHAR(32) NOT NULL,
+  source_key TEXT NOT NULL,
+  organization_name TEXT NOT NULL,
+  domain TEXT,
+  proposed_status VARCHAR(32),
+  proposed_objection VARCHAR(64),
+  confidence SMALLINT,
+  contacts_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  projects_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  interactions_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  evidence_summary TEXT NOT NULL DEFAULT '',
+  matched_organization_id UUID REFERENCES sales_organizations(id) ON DELETE SET NULL,
+  state VARCHAR(16) NOT NULL DEFAULT 'PENDING',
+  created_at TIMESTAMPTZ NOT NULL,
+  reviewed_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS sales_import_candidates_source_key_uq
+  ON sales_import_candidates (source_type, source_key);
+CREATE INDEX IF NOT EXISTS sales_import_candidates_state_idx
+  ON sales_import_candidates (state, created_at DESC);

--- a/pages/api/internal/sales-import.ts
+++ b/pages/api/internal/sales-import.ts
@@ -1,0 +1,61 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { hasInternalUploadSession } from "../../../lib/internal-auth";
+import { approveSalesImportCandidate, createSalesImportCandidate, ignoreSalesImportCandidate } from "../../../lib/sales-import-store";
+import { isSalesObjectionCode, isSalesOrganizationStatus } from "../../../lib/sales-memory";
+
+function value(body: NextApiRequest["body"], key: string): string {
+  const candidate = body?.[key];
+  return typeof candidate === "string" ? candidate.trim() : "";
+}
+
+function parseArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return [];
+  const parsed = JSON.parse(value);
+  if (!Array.isArray(parsed)) throw new Error("Import bundle fields must be arrays.");
+  return parsed;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!(await hasInternalUploadSession(req))) return res.status(401).json({ error: "Internal session required." });
+  if (req.method !== "POST") return res.status(405).setHeader("Allow", "POST").json({ error: "Method not allowed." });
+
+  const action = value(req.body, "action");
+  try {
+    if (action === "approve") {
+      const id = value(req.body, "candidateId");
+      if (!id) return res.status(400).json({ error: "Candidate id is required." });
+      const organizationId = await approveSalesImportCandidate(id, value(req.body, "organizationId") || undefined);
+      return res.redirect(303, `/internal/sales/organizations/${encodeURIComponent(organizationId)}`);
+    }
+    if (action === "ignore") {
+      const id = value(req.body, "candidateId");
+      if (!id) return res.status(400).json({ error: "Candidate id is required." });
+      await ignoreSalesImportCandidate(id);
+      return res.redirect(303, "/internal/sales/import-review");
+    }
+    if (action === "create_candidate") {
+      const organizationName = value(req.body, "organizationName");
+      const sourceType = value(req.body, "sourceType") || "GMAIL";
+      const sourceKey = value(req.body, "sourceKey");
+      if (!organizationName || !sourceKey) return res.status(400).json({ error: "Organization name and source key are required." });
+      const proposedStatus = value(req.body, "proposedStatus");
+      const proposedObjection = value(req.body, "proposedObjection");
+      if (proposedStatus && !isSalesOrganizationStatus(proposedStatus)) return res.status(400).json({ error: "Invalid proposed status." });
+      if (proposedObjection && !isSalesObjectionCode(proposedObjection)) return res.status(400).json({ error: "Invalid proposed objection." });
+      const confidenceRaw = value(req.body, "confidence");
+      const confidence = confidenceRaw ? Number(confidenceRaw) : undefined;
+      if (confidence != null && (!Number.isInteger(confidence) || confidence < 0 || confidence > 100)) return res.status(400).json({ error: "Confidence must be an integer from 0 to 100." });
+      const candidate = await createSalesImportCandidate({
+        sourceType, sourceKey, organizationName, domain: value(req.body, "domain") || undefined,
+        proposedStatus: proposedStatus || undefined, proposedObjection: proposedObjection || undefined, confidence,
+        contacts: parseArray(req.body?.contacts) as never[], projects: parseArray(req.body?.projects) as never[], interactions: parseArray(req.body?.interactions) as never[],
+        evidenceSummary: value(req.body, "evidenceSummary"), matchedOrganizationId: value(req.body, "matchedOrganizationId") || undefined,
+      });
+      return res.status(201).json({ candidate });
+    }
+    return res.status(400).json({ error: "Unknown sales import action." });
+  } catch (error) {
+    return res.status(500).json({ error: error instanceof Error ? error.message : "Sales import update failed." });
+  }
+}

--- a/pages/internal/sales/import-review.tsx
+++ b/pages/internal/sales/import-review.tsx
@@ -1,0 +1,92 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { listSalesImportCandidates, type SalesImportCandidate } from "../../../lib/sales-import-store";
+import { listSalesOrganizations, type SalesOrganization } from "../../../lib/sales-store";
+
+interface Props { candidates: SalesImportCandidate[]; organizations: SalesOrganization[]; }
+
+export const getServerSideProps: GetServerSideProps<Props> = async () => {
+  const [candidates, organizations] = await Promise.all([listSalesImportCandidates("PENDING"), listSalesOrganizations("")]);
+  return { props: { candidates, organizations } };
+};
+
+function formatDate(value: string) { return new Date(value).toLocaleString(); }
+function confidenceClass(value?: number) {
+  if ((value ?? 0) >= 85) return "bg-green-50 text-green-700";
+  if ((value ?? 0) >= 60) return "bg-amber-50 text-amber-700";
+  return "bg-gray-100 text-gray-700";
+}
+
+export default function SalesImportReviewPage({ candidates, organizations }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return <>
+    <Head><title>Sales Import Review | Article6 Internal</title><meta name="robots" content="noindex,nofollow" /></Head>
+    <main className="min-h-screen bg-gray-50 px-4 py-10 text-gray-900"><div className="mx-auto max-w-6xl">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-forest-700">Article6 internal tool</p>
+          <h1 className="mt-2 text-2xl font-bold tracking-tight">Import verification</h1>
+          <p className="mt-2 text-sm text-gray-600">Machine-reconstructed sales history stays untrusted until you approve it.</p>
+        </div>
+        <Link href="/internal/sales" className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700">Back to sales memory</Link>
+      </div>
+
+      <div className="mt-6 rounded-lg border border-gray-200 bg-white px-5 py-4 shadow-sm">
+        <div className="text-sm"><span className="font-semibold">{candidates.length}</span> pending organization bundle{candidates.length === 1 ? "" : "s"}</div>
+        <p className="mt-1 text-xs text-gray-500">Approve creates or merges the organization, contacts, projects and append-only interactions in one transaction. Ignore preserves the candidate as reviewed but does not alter sales memory.</p>
+      </div>
+
+      <div className="mt-6 space-y-5">
+        {candidates.length === 0 ? <div className="rounded-lg border border-gray-200 bg-white p-6 text-sm text-gray-600 shadow-sm">No import candidates waiting for review.</div> : candidates.map((candidate) => <article key={candidate.id} className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-lg font-semibold">{candidate.organizationName}</h2>
+                <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${confidenceClass(candidate.confidence)}`}>{candidate.confidence == null ? "Unscored" : `${candidate.confidence}% confidence`}</span>
+                <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-semibold text-gray-700">{candidate.sourceType}</span>
+              </div>
+              <p className="mt-1 text-sm text-gray-500">{candidate.domain || "No domain inferred"} · imported {formatDate(candidate.createdAt)}</p>
+            </div>
+            <div className="text-right text-xs text-gray-500">Source key<br/><span className="font-mono">{candidate.sourceKey}</span></div>
+          </div>
+
+          {candidate.evidenceSummary ? <div className="mt-4 rounded-md bg-gray-50 p-3 text-sm text-gray-700">{candidate.evidenceSummary}</div> : null}
+
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            <section className="rounded-md border border-gray-200 p-3"><h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Contacts · {candidate.contacts.length}</h3>
+              <div className="mt-2 space-y-2 text-sm">{candidate.contacts.length ? candidate.contacts.map((contact, index) => <div key={`${contact.email || contact.name}-${index}`}><div className="font-medium">{contact.name}</div><div className="text-xs text-gray-500">{contact.title || "No title"}{contact.email ? ` · ${contact.email}` : ""}</div></div>) : <span className="text-gray-500">None inferred</span>}</div>
+            </section>
+            <section className="rounded-md border border-gray-200 p-3"><h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Projects · {candidate.projects.length}</h3>
+              <div className="mt-2 space-y-2 text-sm">{candidate.projects.length ? candidate.projects.map((project, index) => <div key={`${project.vcsId || project.name}-${index}`}><div className="font-medium">{project.vcsId ? `VCS ${project.vcsId} · ` : ""}{project.name}</div><div className="text-xs text-gray-500">{[project.methodology, project.methodologyVersion, project.role].filter(Boolean).join(" · ") || "No extra metadata"}</div></div>) : <span className="text-gray-500">None inferred</span>}</div>
+            </section>
+            <section className="rounded-md border border-gray-200 p-3"><h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Proposed disposition</h3>
+              <div className="mt-2 text-sm"><div className="font-medium">{candidate.proposedStatus || "No status change"}</div><div className="text-xs text-gray-500">{candidate.proposedObjection || "No objection inferred"}</div></div>
+            </section>
+          </div>
+
+          <section className="mt-4 rounded-md border border-gray-200 p-3"><h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Interactions · {candidate.interactions.length}</h3>
+            <div className="mt-2 divide-y divide-gray-100">{candidate.interactions.length ? candidate.interactions.map((interaction, index) => <div key={`${interaction.externalReference || interaction.occurredAt}-${index}`} className="py-2 text-sm">
+              <div className="flex flex-wrap gap-x-3 gap-y-1"><span className="font-medium">{interaction.direction || "INTERNAL"} {interaction.channel || "EMAIL"}</span><span className="text-gray-500">{formatDate(interaction.occurredAt)}</span>{interaction.contactEmail ? <span className="text-gray-500">{interaction.contactEmail}</span> : null}</div>
+              {interaction.subject ? <div className="mt-1 text-xs font-medium text-gray-600">{interaction.subject}</div> : null}<div className="mt-1 text-gray-700">{interaction.summary}</div>
+            </div>) : <div className="py-2 text-sm text-gray-500">No interactions inferred.</div>}</div>
+          </section>
+
+          <div className="mt-5 flex flex-wrap items-end gap-3 border-t border-gray-100 pt-4">
+            <form method="post" action="/api/internal/sales-import" className="flex flex-1 flex-wrap items-end gap-3">
+              <input type="hidden" name="action" value="approve"/><input type="hidden" name="candidateId" value={candidate.id}/>
+              <label className="min-w-[280px] flex-1 text-xs font-medium text-gray-600">Approve into organization
+                <select name="organizationId" defaultValue={candidate.matchedOrganizationId || ""} className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900">
+                  <option value="">Create new organization</option>
+                  {organizations.map((organization) => <option key={organization.id} value={organization.id}>{organization.name}{organization.domain ? ` · ${organization.domain}` : ""}</option>)}
+                </select>
+              </label>
+              {candidate.matchedOrganizationName ? <div className="pb-2 text-xs font-medium text-forest-700">Auto-match: {candidate.matchedOrganizationName}</div> : null}
+              <button className="rounded-md bg-forest-700 px-4 py-2 text-sm font-medium text-white hover:bg-forest-800">Approve bundle</button>
+            </form>
+            <form method="post" action="/api/internal/sales-import"><input type="hidden" name="action" value="ignore"/><input type="hidden" name="candidateId" value={candidate.id}/><button className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700">Ignore</button></form>
+          </div>
+        </article>)}
+      </div>
+    </div></main>
+  </>;
+}

--- a/pages/internal/sales/index.tsx
+++ b/pages/internal/sales/index.tsx
@@ -28,6 +28,7 @@ export default function SalesIndexPage({ organizations, search }: InferGetServer
       <p className="text-sm font-semibold uppercase tracking-wide text-forest-700">Article6 internal tool</p>
       <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
         <div><h1 className="text-2xl font-bold tracking-tight">Sales memory</h1><p className="mt-2 text-sm text-gray-600">Organization-first relationship history. Search before contacting anyone.</p></div>
+        <Link href="/internal/sales/import-review" className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700">Review imports</Link>
       </div>
 
       <form method="get" className="mt-6 flex gap-2">


### PR DESCRIPTION
## What changed

Adds PR2 of the internal sales-memory build: a verification queue for machine-reconstructed historical outreach.

- adds `sales_import_candidates` as organization-level import bundles
- each bundle can contain multiple contacts, projects, and append-only interactions
- adds `/internal/sales/import-review`
- approve either creates a new organization or merges into an existing one
- approval writes the full bundle in one transaction and applies validated proposed disposition/objection state
- ignore marks a candidate reviewed without changing trusted sales memory
- adds protected candidate-ingest API for Gmail/backfill tooling
- preserves source key, evidence summary, confidence, and auto-match provenance
- adds Review imports entry from `/internal/sales`

## Why

Historical sales data is spread across Gmail and project lists. Re-entering it manually would be slow and error-prone. This layer lets automated extraction do the archaeology while keeping the user as the trust boundary.

## Important architecture choice

This PR does not add Gmail OAuth or Gmail credentials to Article6. Gmail extraction can be performed by the existing connected tooling and loaded as candidates. The Article6 app stores and verifies candidate bundles, keeping mail access outside the production application.

## Migration

Required: `migrations/004_create_sales_import_candidates.sql`

## Scope

No email sending. No automatic approval. No continuous Gmail sync. No changes to intake/Quick Check behavior.