### PR TITLE
Exclude internal routes from Vercel Analytics

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -31,7 +31,17 @@ function MyApp({ Component, pageProps, router }: AppProps) {
           <Component {...pageProps} />
         </Layout>
       )}
-      <Analytics />
+      <Analytics
+        beforeSend={(event) => {
+          const pathname = new URL(event.url).pathname;
+
+          if (pathname.startsWith('/internal/') || pathname.startsWith('/preview/')) {
+            return null;
+          }
+
+          return event;
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- stop Vercel Web Analytics events from `/internal/*`
- also exclude `/preview/*` routes
- keep public production analytics unchanged

## Scope
- one-file analytics-only change
- no migration
- no intake/backend behavior changes

## Expected result
Internal sales/CRM navigation will no longer contaminate future visitor and page-view analytics. Existing historical analytics remain unchanged.