### PR TITLE
Add read-only auth for internal sales agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,10 +28,16 @@ APP_ARTICLE6_PROCESSOR_URL=
 APP_ARTICLE6_PROCESSOR_SECRET=
 APP_ARTICLE6_PROCESSOR_TIMEOUT_MS=180000
 
-# Internal PDD upload protection (server-only; never use NEXT_PUBLIC_* names)
-# The /internal/submissions/new route uses HTTP Basic Auth and issues a short-lived HttpOnly session cookie.
+# Internal admin protection (server-only; never use NEXT_PUBLIC_* names)
+# Admin credentials retain the existing access to /internal/* and mutation endpoints.
 INTERNAL_UPLOAD_USERNAME=
 INTERNAL_UPLOAD_PASSWORD=
+
+# Read-only sales agent protection (server-only)
+# Restricted in middleware to GET/HEAD/OPTIONS under /internal/sales only.
+# The agent credential is never issued the admin internal-session cookie used by mutation APIs.
+INTERNAL_SALES_AGENT_USERNAME=
+INTERNAL_SALES_AGENT_PASSWORD=
 
 # Google Sheets (existing, for leaderboard)
 GOOGLE_SHEETS_CLIENT_EMAIL=

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,41 +3,68 @@ import { createInternalSessionToken, INTERNAL_SESSION_COOKIE } from "./lib/inter
 
 export const config = { matcher: ["/internal/:path*"] };
 
+const SALES_AGENT_PREFIX = "/internal/sales";
+const READ_ONLY_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+function unauthorized(message = "Authentication required.") {
+  return new NextResponse(message, {
+    status: 401,
+    headers: { "WWW-Authenticate": 'Basic realm="Article6 internal uploads", charset="UTF-8"' },
+  });
+}
+
 export default async function middleware(request: NextRequest) {
-  const username = process.env.INTERNAL_UPLOAD_USERNAME;
-  const password = process.env.INTERNAL_UPLOAD_PASSWORD;
-  if (!username || !password) {
+  const adminUsername = process.env.INTERNAL_UPLOAD_USERNAME;
+  const adminPassword = process.env.INTERNAL_UPLOAD_PASSWORD;
+  if (!adminUsername || !adminPassword) {
     return new NextResponse("Internal upload protection is not configured.", { status: 503 });
   }
 
   const authorization = request.headers.get("authorization");
-  if (!authorization?.startsWith("Basic ")) {
-    return new NextResponse("Authentication required.", {
-      status: 401,
-      headers: { "WWW-Authenticate": 'Basic realm="Article6 internal uploads", charset="UTF-8"' },
-    });
-  }
+  if (!authorization?.startsWith("Basic ")) return unauthorized();
 
   let suppliedUsername = "";
   let suppliedPassword = "";
   try {
     const decoded = atob(authorization.slice(6));
     const separator = decoded.indexOf(":");
-    suppliedUsername = decoded.slice(0, separator);
-    suppliedPassword = decoded.slice(separator + 1);
+    if (separator >= 0) {
+      suppliedUsername = decoded.slice(0, separator);
+      suppliedPassword = decoded.slice(separator + 1);
+    }
   } catch {
     suppliedUsername = "";
+    suppliedPassword = "";
   }
 
-  if (suppliedUsername !== username || suppliedPassword !== password) {
-    return new NextResponse("Invalid credentials.", {
-      status: 401,
-      headers: { "WWW-Authenticate": 'Basic realm="Article6 internal uploads", charset="UTF-8"' },
-    });
+  const isAdmin = suppliedUsername === adminUsername && suppliedPassword === adminPassword;
+
+  const agentUsername = process.env.INTERNAL_SALES_AGENT_USERNAME;
+  const agentPassword = process.env.INTERNAL_SALES_AGENT_PASSWORD;
+  const isSalesAgent = Boolean(
+    agentUsername &&
+      agentPassword &&
+      suppliedUsername === agentUsername &&
+      suppliedPassword === agentPassword,
+  );
+
+  if (!isAdmin && !isSalesAgent) return unauthorized("Invalid credentials.");
+
+  if (isSalesAgent) {
+    if (!request.nextUrl.pathname.startsWith(SALES_AGENT_PREFIX)) {
+      return new NextResponse("Sales agent access is restricted to /internal/sales.", { status: 403 });
+    }
+    if (!READ_ONLY_METHODS.has(request.method)) {
+      return new NextResponse("Sales agent access is read-only.", { status: 403 });
+    }
+
+    // Do not issue the admin internal-session cookie for the agent credential.
+    // Mutation APIs require that admin-only cookie via hasInternalUploadSession().
+    return NextResponse.next();
   }
 
   const response = NextResponse.next();
-  response.cookies.set(INTERNAL_SESSION_COOKIE, await createInternalSessionToken(username, password), {
+  response.cookies.set(INTERNAL_SESSION_COOKIE, await createInternalSessionToken(adminUsername, adminPassword), {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "strict",


### PR DESCRIPTION
Adds a dedicated Basic Auth path for a read-only sales agent.

Security behavior:
- Existing admin credentials remain unchanged.
- New `INTERNAL_SALES_AGENT_USERNAME` / `INTERNAL_SALES_AGENT_PASSWORD` credentials are restricted to `/internal/sales*`.
- Agent credentials are allowed only `GET`, `HEAD`, and `OPTIONS`.
- Agent credentials are not issued the admin internal-session cookie used by mutation APIs.
- Existing sales POST mutation API therefore remains admin-only.

Vercel still needs the two new Production environment variables added before this can be used.