### PR TITLE
Track sales experiments in internal CRM

### DIFF
--- a/lib/sales-memory.ts
+++ b/lib/sales-memory.ts
@@ -11,6 +11,15 @@ export const SALES_ORGANIZATION_STATUSES = [
 
 export type SalesOrganizationStatus = (typeof SALES_ORGANIZATION_STATUSES)[number];
 
+export const SALES_EXPERIMENTS = [
+  "ARTICLE6_CARBON",
+  "TENDER_READINESS",
+  "ECOVADIS_SUPPLIER_COMPLIANCE",
+  "OTHER",
+] as const;
+
+export type SalesExperiment = (typeof SALES_EXPERIMENTS)[number];
+
 export const SALES_OBJECTION_CODES = [
   "INTERNAL_TEAM",
   "ALREADY_COVERED",
@@ -44,6 +53,10 @@ export function normalizeOptional(value: unknown): string | null {
 
 export function isSalesOrganizationStatus(value: unknown): value is SalesOrganizationStatus {
   return typeof value === "string" && SALES_ORGANIZATION_STATUSES.includes(value as SalesOrganizationStatus);
+}
+
+export function isSalesExperiment(value: unknown): value is SalesExperiment {
+  return typeof value === "string" && SALES_EXPERIMENTS.includes(value as SalesExperiment);
 }
 
 export function isSalesObjectionCode(value: unknown): value is SalesObjectionCode {

--- a/lib/sales-store.ts
+++ b/lib/sales-store.ts
@@ -3,6 +3,7 @@ import { Pool, type QueryResultRow } from "pg";
 import {
   normalizeDomain,
   normalizeOrganizationName,
+  type SalesExperiment,
   type SalesObjectionCode,
   type SalesOrganizationStatus,
 } from "./sales-memory";
@@ -12,6 +13,7 @@ export interface SalesOrganization {
   name: string;
   domain?: string;
   country?: string;
+  experiment: SalesExperiment;
   status: SalesOrganizationStatus;
   objectionCode?: SalesObjectionCode;
   internalCertificationTeam?: boolean;
@@ -99,6 +101,7 @@ function toOrganization(row: QueryResultRow): SalesOrganization {
     name: String(row.name),
     domain: row.domain || undefined,
     country: row.country || undefined,
+    experiment: (row.experiment || "ARTICLE6_CARBON") as SalesExperiment,
     status: row.status as SalesOrganizationStatus,
     objectionCode: row.objection_code || undefined,
     internalCertificationTeam: row.internal_certification_team == null ? undefined : Boolean(row.internal_certification_team),
@@ -123,6 +126,7 @@ export async function listSalesOrganizations(search = ""): Promise<SalesOrganiza
      WHERE $1 = ''
         OR o.name ILIKE '%' || $1 || '%'
         OR COALESCE(o.domain, '') ILIKE '%' || $1 || '%'
+        OR COALESCE(o.experiment, '') ILIKE '%' || $1 || '%'
         OR EXISTS (SELECT 1 FROM sales_contacts c WHERE c.organization_id = o.id AND (c.name ILIKE '%' || $1 || '%' OR COALESCE(c.email, '') ILIKE '%' || $1 || '%'))
         OR EXISTS (SELECT 1 FROM sales_organization_projects op JOIN sales_projects p ON p.id = op.project_id WHERE op.organization_id = o.id AND (p.name ILIKE '%' || $1 || '%' OR COALESCE(p.vcs_id, '') ILIKE '%' || $1 || '%' OR COALESCE(p.methodology, '') ILIKE '%' || $1 || '%'))
      ORDER BY COALESCE((SELECT MAX(i.occurred_at) FROM sales_interactions i WHERE i.organization_id = o.id), o.updated_at) DESC, o.name ASC`,
@@ -131,7 +135,7 @@ export async function listSalesOrganizations(search = ""): Promise<SalesOrganiza
   return result.rows.map(toOrganization);
 }
 
-export async function createSalesOrganization(input: { name: string; domain?: string; country?: string; notes?: string }): Promise<{ organization: SalesOrganization; created: boolean }> {
+export async function createSalesOrganization(input: { name: string; domain?: string; country?: string; experiment?: SalesExperiment; notes?: string }): Promise<{ organization: SalesOrganization; created: boolean }> {
   const now = new Date().toISOString();
   const normalizedName = normalizeOrganizationName(input.name);
   const domain = normalizeDomain(input.domain || "");
@@ -141,9 +145,9 @@ export async function createSalesOrganization(input: { name: string; domain?: st
   );
   if (existing.rows[0]) return { organization: toOrganization(existing.rows[0]), created: false };
   const result = await getPool().query(
-    `INSERT INTO sales_organizations (id, name, normalized_name, domain, country, status, notes, do_not_contact, created_at, updated_at)
-     VALUES ($1,$2,$3,$4,$5,'NEW',$6,FALSE,$7,$7) RETURNING *`,
-    [randomUUID(), input.name.trim(), normalizedName, domain, input.country?.trim() || null, input.notes?.trim() || "", now]
+    `INSERT INTO sales_organizations (id, name, normalized_name, domain, country, experiment, status, notes, do_not_contact, created_at, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,'NEW',$7,FALSE,$8,$8) RETURNING *`,
+    [randomUUID(), input.name.trim(), normalizedName, domain, input.country?.trim() || null, input.experiment || "ARTICLE6_CARBON", input.notes?.trim() || "", now]
   );
   return { organization: toOrganization(result.rows[0]), created: true };
 }
@@ -197,10 +201,10 @@ export async function addSalesInteraction(input: { organizationId: string; conta
   await getPool().query("UPDATE sales_organizations SET updated_at = $2 WHERE id = $1", [input.organizationId, createdAt]);
 }
 
-export async function updateSalesOrganizationState(input: { organizationId: string; status: SalesOrganizationStatus; objectionCode?: SalesObjectionCode; internalCertificationTeam?: boolean; doNotContact?: boolean; notes?: string }): Promise<void> {
+export async function updateSalesOrganizationState(input: { organizationId: string; status: SalesOrganizationStatus; experiment?: SalesExperiment; objectionCode?: SalesObjectionCode; internalCertificationTeam?: boolean; doNotContact?: boolean; notes?: string }): Promise<void> {
   await getPool().query(
-    `UPDATE sales_organizations SET status=$2, objection_code=$3, internal_certification_team=$4, do_not_contact=$5, notes=$6, updated_at=$7 WHERE id=$1`,
-    [input.organizationId, input.status, input.objectionCode || null, input.internalCertificationTeam ?? null, Boolean(input.doNotContact), input.notes?.trim() || "", new Date().toISOString()]
+    `UPDATE sales_organizations SET status=$2, experiment=$3, objection_code=$4, internal_certification_team=$5, do_not_contact=$6, notes=$7, updated_at=$8 WHERE id=$1`,
+    [input.organizationId, input.status, input.experiment || "ARTICLE6_CARBON", input.objectionCode || null, input.internalCertificationTeam ?? null, Boolean(input.doNotContact), input.notes?.trim() || "", new Date().toISOString()]
   );
 }
 

--- a/migrations/005_add_sales_experiment.sql
+++ b/migrations/005_add_sales_experiment.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sales_organizations
+  ADD COLUMN IF NOT EXISTS experiment VARCHAR(64) NOT NULL DEFAULT 'ARTICLE6_CARBON';
+
+CREATE INDEX IF NOT EXISTS sales_organizations_experiment_idx
+  ON sales_organizations (experiment);

--- a/pages/api/internal/sales.ts
+++ b/pages/api/internal/sales.ts
@@ -7,7 +7,7 @@ import {
   createSalesOrganization,
   updateSalesOrganizationState,
 } from "../../../lib/sales-store";
-import { isSalesObjectionCode, isSalesOrganizationStatus, normalizeOptional } from "../../../lib/sales-memory";
+import { isSalesExperiment, isSalesObjectionCode, isSalesOrganizationStatus, normalizeOptional } from "../../../lib/sales-memory";
 
 function value(body: NextApiRequest["body"], key: string): string {
   const candidate = body?.[key];
@@ -29,8 +29,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     if (action === "create_organization") {
       const name = value(req.body, "name");
+      const experiment = value(req.body, "experiment") || "ARTICLE6_CARBON";
       if (!name) return res.status(400).json({ error: "Organization name is required." });
-      const result = await createSalesOrganization({ name, domain: value(req.body, "domain"), country: value(req.body, "country"), notes: value(req.body, "notes") });
+      if (!isSalesExperiment(experiment)) return res.status(400).json({ error: "Invalid sales experiment." });
+      const result = await createSalesOrganization({ name, domain: value(req.body, "domain"), country: value(req.body, "country"), experiment, notes: value(req.body, "notes") });
       return organizationRedirect(res, result.organization.id, result.created ? undefined : { duplicate: "1" });
     }
 
@@ -73,14 +75,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     if (action === "update_status") {
       const status = value(req.body, "status");
+      const experiment = value(req.body, "experiment") || "ARTICLE6_CARBON";
       const objection = value(req.body, "objectionCode");
       if (!isSalesOrganizationStatus(status)) return res.status(400).json({ error: "Invalid organization status." });
+      if (!isSalesExperiment(experiment)) return res.status(400).json({ error: "Invalid sales experiment." });
       const objectionCode = objection && isSalesObjectionCode(objection) ? objection : undefined;
       if (objection && !objectionCode) return res.status(400).json({ error: "Invalid objection code." });
       const internalTeamValue = value(req.body, "internalCertificationTeam");
       await updateSalesOrganizationState({
         organizationId,
         status,
+        experiment,
         objectionCode,
         internalCertificationTeam: internalTeamValue === "" ? undefined : internalTeamValue === "true",
         doNotContact: req.body?.doNotContact === "on",

--- a/pages/internal/sales/index.tsx
+++ b/pages/internal/sales/index.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import SalesMemorySearch, { type SalesMemorySearchEntry } from "../../../components/SalesMemorySearch";
 import { getSalesOrganizationDetail, listSalesOrganizations, type SalesOrganization } from "../../../lib/sales-store";
+import { SALES_EXPERIMENTS } from "../../../lib/sales-memory";
 
 interface Props { organizations: SalesOrganization[]; searchEntries: SalesMemorySearchEntry[]; }
 
@@ -21,8 +22,8 @@ export const getServerSideProps: GetServerSideProps<Props> = async () => {
       kind: "organization",
       organizationId: organization.id,
       title: organization.name,
-      subtitle: organization.domain || "No domain",
-      searchText: [organization.name, organization.domain].filter(Boolean).join(" ").toLowerCase(),
+      subtitle: [organization.domain || "No domain", organization.experiment].join(" · "),
+      searchText: [organization.name, organization.domain, organization.experiment].filter(Boolean).join(" ").toLowerCase(),
       status: organization.status,
       doNotContact: organization.doNotContact,
     });
@@ -34,7 +35,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async () => {
         organizationId: organization.id,
         title: project.vcsId ? `VCS ${project.vcsId} · ${project.name}` : project.name,
         subtitle: [organization.name, project.methodology && `${project.methodology}${project.methodologyVersion ? ` ${project.methodologyVersion}` : ""}`].filter(Boolean).join(" · "),
-        searchText: [project.vcsId, project.name, project.methodology, project.methodologyVersion, organization.name].filter(Boolean).join(" ").toLowerCase(),
+        searchText: [project.vcsId, project.name, project.methodology, project.methodologyVersion, organization.name, organization.experiment].filter(Boolean).join(" ").toLowerCase(),
         status: organization.status,
         doNotContact: organization.doNotContact,
       });
@@ -47,7 +48,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async () => {
         organizationId: organization.id,
         title: contact.name,
         subtitle: [organization.name, contact.email].filter(Boolean).join(" · "),
-        searchText: [contact.name, contact.email, organization.name].filter(Boolean).join(" ").toLowerCase(),
+        searchText: [contact.name, contact.email, organization.name, organization.experiment].filter(Boolean).join(" ").toLowerCase(),
         status: organization.status,
         doNotContact: organization.doNotContact,
       });
@@ -68,13 +69,20 @@ function statusClass(status: string) {
   return "bg-gray-100 text-gray-700";
 }
 
+function experimentLabel(value: string) {
+  if (value === "ARTICLE6_CARBON") return "Article6 Carbon";
+  if (value === "TENDER_READINESS") return "Tender Readiness";
+  if (value === "ECOVADIS_SUPPLIER_COMPLIANCE") return "EcoVadis / Supplier Compliance";
+  return "Other";
+}
+
 export default function SalesIndexPage({ organizations, searchEntries }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return <>
     <Head><title>Sales Memory | Article6 Internal</title><meta name="robots" content="noindex,nofollow" /></Head>
     <main className="min-h-screen bg-gray-50 px-4 py-10 text-gray-900"><div className="mx-auto max-w-6xl">
-      <p className="text-sm font-semibold uppercase tracking-wide text-forest-700">Article6 internal tool</p>
+      <p className="text-sm font-semibold uppercase tracking-wide text-forest-700">Internal experiments & sales</p>
       <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
-        <div><h1 className="text-2xl font-bold tracking-tight">Sales memory</h1><p className="mt-2 text-sm text-gray-600">Search first. See the relationship history before contacting anyone.</p></div>
+        <div><h1 className="text-2xl font-bold tracking-tight">Sales memory</h1><p className="mt-2 text-sm text-gray-600">Search first. Keep every experiment in one history so we do not re-contact people blindly.</p></div>
         <Link href="/internal/sales/import-review" className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700">Review imports</Link>
       </div>
 
@@ -84,11 +92,12 @@ export default function SalesIndexPage({ organizations, searchEntries }: InferGe
         <details>
           <summary className="cursor-pointer list-none text-sm font-medium text-gray-500 hover:text-gray-800">+ Add organization manually</summary>
           <section className="mt-3 rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
-            <form method="post" action="/api/internal/sales" className="grid gap-3 md:grid-cols-4">
+            <form method="post" action="/api/internal/sales" className="grid gap-3 md:grid-cols-5">
               <input type="hidden" name="action" value="create_organization" />
               <input required name="name" placeholder="Organization name" className="rounded-md border border-gray-300 px-3 py-2 text-sm" />
               <input name="domain" placeholder="Domain" className="rounded-md border border-gray-300 px-3 py-2 text-sm" />
               <input name="country" placeholder="Country" className="rounded-md border border-gray-300 px-3 py-2 text-sm" />
+              <select name="experiment" defaultValue="ARTICLE6_CARBON" className="rounded-md border border-gray-300 px-3 py-2 text-sm">{SALES_EXPERIMENTS.map((value) => <option key={value} value={value}>{experimentLabel(value)}</option>)}</select>
               <button className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white">Add organization</button>
             </form>
           </section>
@@ -98,9 +107,10 @@ export default function SalesIndexPage({ organizations, searchEntries }: InferGe
       <div className="mt-7 flex items-baseline justify-between gap-4"><div><h2 className="text-base font-semibold">Organizations</h2><p className="mt-1 text-xs text-gray-500">Most recently active first.</p></div><span className="text-xs text-gray-500">{organizations.length} total</span></div>
       <div className="mt-3 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
         {organizations.length === 0 ? <p className="p-6 text-sm text-gray-600">No organizations found.</p> : <div className="overflow-x-auto"><table className="min-w-full divide-y divide-gray-200 text-left text-sm">
-          <thead className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500"><tr><th className="px-5 py-3">Organization</th><th className="px-5 py-3">Status</th><th className="px-5 py-3">Projects</th><th className="px-5 py-3">Last interaction</th><th className="px-5 py-3"><span className="sr-only">Action</span></th></tr></thead>
+          <thead className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500"><tr><th className="px-5 py-3">Organization</th><th className="px-5 py-3">Experiment</th><th className="px-5 py-3">Status</th><th className="px-5 py-3">Projects</th><th className="px-5 py-3">Last interaction</th><th className="px-5 py-3"><span className="sr-only">Action</span></th></tr></thead>
           <tbody className="divide-y divide-gray-100">{organizations.map((organization) => <tr key={organization.id} className={organization.doNotContact ? "bg-red-50/50" : "hover:bg-gray-50"}>
             <td className="px-5 py-4"><div className="font-medium text-gray-900">{organization.name}</div><div className="text-xs text-gray-500">{organization.domain || "No domain"}</div></td>
+            <td className="px-5 py-4"><span className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">{experimentLabel(organization.experiment)}</span></td>
             <td className="px-5 py-4"><span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${statusClass(organization.status)}`}>{organization.status}</span>{organization.doNotContact ? <div className="mt-1 text-xs font-semibold text-red-700">DO NOT CONTACT</div> : null}</td>
             <td className="px-5 py-4">{organization.projectCount || 0}</td>
             <td className="whitespace-nowrap px-5 py-4 text-gray-600">{formatDate(organization.lastInteractionAt)}</td>

--- a/pages/internal/sales/organizations/[id].tsx
+++ b/pages/internal/sales/organizations/[id].tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { getSalesOrganizationDetail, type SalesOrganizationDetail } from "../../../../lib/sales-store";
-import { SALES_OBJECTION_CODES, SALES_ORGANIZATION_STATUSES } from "../../../../lib/sales-memory";
+import { SALES_EXPERIMENTS, SALES_OBJECTION_CODES, SALES_ORGANIZATION_STATUSES } from "../../../../lib/sales-memory";
 
 interface Props { detail: SalesOrganizationDetail; duplicate: boolean; error?: string; }
 
@@ -20,6 +20,13 @@ function websiteHref(domain?: string): string | undefined {
   return /^https?:\/\//i.test(domain) ? domain : `https://${domain}`;
 }
 
+function experimentLabel(value: string) {
+  if (value === "ARTICLE6_CARBON") return "Article6 Carbon";
+  if (value === "TENDER_READINESS") return "Tender Readiness";
+  if (value === "ECOVADIS_SUPPLIER_COMPLIANCE") return "EcoVadis / Supplier Compliance";
+  return "Other";
+}
+
 export default function OrganizationPage({ detail, duplicate, error }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { organization, contacts, projects, interactions } = detail;
   const website = websiteHref(organization.domain);
@@ -29,39 +36,23 @@ export default function OrganizationPage({ detail, duplicate, error }: InferGetS
     <main className="min-h-screen bg-gray-50 px-4 py-10 text-gray-900"><div className="mx-auto max-w-6xl">
       <Link href="/internal/sales" className="text-sm font-medium text-forest-700">← Sales memory</Link>
       <div className="mt-4 flex flex-wrap items-start justify-between gap-4">
-        <div><h1 className="text-3xl font-bold tracking-tight">{organization.name}</h1><p className="mt-1 text-sm text-gray-600">{organization.domain || "No domain recorded"}{organization.country ? ` · ${organization.country}` : ""}</p></div>
+        <div><h1 className="text-3xl font-bold tracking-tight">{organization.name}</h1><p className="mt-1 text-sm text-gray-600">{organization.domain || "No domain recorded"}{organization.country ? ` · ${organization.country}` : ""}</p><div className="mt-2"><span className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">{experimentLabel(organization.experiment)}</span></div></div>
         <div className="text-right"><div className="text-sm font-semibold">{organization.status}</div>{organization.objectionCode ? <div className="mt-1 text-xs text-gray-500">{organization.objectionCode}</div> : null}{organization.doNotContact ? <div className="mt-2 rounded bg-red-100 px-2 py-1 text-xs font-bold text-red-700">DO NOT CONTACT</div> : null}</div>
       </div>
       {duplicate ? <div className="mt-5 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">Duplicate prevented. This existing organization matched the name or domain you entered.</div> : null}
       {error ? <div className="mt-5 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">{error}</div> : null}
 
       <section className="mt-6 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
-        <div className="border-b border-gray-100 px-5 py-3">
-          <h2 className="text-sm font-semibold text-gray-900">Account overview</h2>
-        </div>
+        <div className="border-b border-gray-100 px-5 py-3"><h2 className="text-sm font-semibold text-gray-900">Account overview</h2></div>
         <div className="grid gap-px bg-gray-100 md:grid-cols-2 lg:grid-cols-4">
-          <div className="bg-white px-5 py-4">
-            <div className="text-xs font-medium uppercase tracking-wide text-gray-500">Company</div>
-            <div className="mt-1 text-base font-semibold text-gray-900">{organization.name}</div>
-          </div>
-          <div className="bg-white px-5 py-4">
-            <div className="text-xs font-medium uppercase tracking-wide text-gray-500">Website</div>
-            {website ? <a href={website} target="_blank" rel="noreferrer" className="mt-1 block text-base font-semibold text-forest-700 hover:underline">{organization.domain}</a> : <div className="mt-1 text-base font-semibold text-gray-500">Not recorded</div>}
-          </div>
-          <div className="bg-white px-5 py-4">
-            <div className="text-xs font-medium uppercase tracking-wide text-gray-500">Projects</div>
-            <div className="mt-1 text-base font-semibold text-gray-900">{projects.length}</div>
-          </div>
-          <div className="bg-white px-5 py-4">
-            <div className="text-xs font-medium uppercase tracking-wide text-gray-500">Interactions</div>
-            <div className="mt-1 text-base font-semibold text-gray-900">{interactions.length}</div>
-          </div>
+          <div className="bg-white px-5 py-4"><div className="text-xs font-medium uppercase tracking-wide text-gray-500">Company</div><div className="mt-1 text-base font-semibold text-gray-900">{organization.name}</div></div>
+          <div className="bg-white px-5 py-4"><div className="text-xs font-medium uppercase tracking-wide text-gray-500">Website</div>{website ? <a href={website} target="_blank" rel="noreferrer" className="mt-1 block text-base font-semibold text-forest-700 hover:underline">{organization.domain}</a> : <div className="mt-1 text-base font-semibold text-gray-500">Not recorded</div>}</div>
+          <div className="bg-white px-5 py-4"><div className="text-xs font-medium uppercase tracking-wide text-gray-500">Projects</div><div className="mt-1 text-base font-semibold text-gray-900">{projects.length}</div></div>
+          <div className="bg-white px-5 py-4"><div className="text-xs font-medium uppercase tracking-wide text-gray-500">Interactions</div><div className="mt-1 text-base font-semibold text-gray-900">{interactions.length}</div></div>
         </div>
 
         <div className="border-t border-gray-100">
-          <div className="hidden grid-cols-[minmax(0,2fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 bg-gray-50 px-5 py-2 text-xs font-medium uppercase tracking-wide text-gray-500 md:grid">
-            <div>Project</div><div>Project ID</div><div>Methodology</div><div>Version</div>
-          </div>
+          <div className="hidden grid-cols-[minmax(0,2fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 bg-gray-50 px-5 py-2 text-xs font-medium uppercase tracking-wide text-gray-500 md:grid"><div>Project</div><div>Project ID</div><div>Methodology</div><div>Version</div></div>
           {projects.length ? projects.map((project) => <div key={project.id} className="grid gap-3 border-t border-gray-100 px-5 py-4 first:border-t-0 md:grid-cols-[minmax(0,2fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] md:items-center md:gap-4">
             <div><div className="text-xs font-medium uppercase tracking-wide text-gray-500 md:hidden">Project</div><div className="mt-1 text-sm font-semibold text-gray-900 md:mt-0">{project.name}</div></div>
             <div><div className="text-xs font-medium uppercase tracking-wide text-gray-500 md:hidden">Project ID</div><div className="mt-1 text-sm font-semibold text-gray-900 md:mt-0">{project.vcsId ? `VCS ${project.vcsId}` : "Not recorded"}</div></div>
@@ -89,7 +80,7 @@ export default function OrganizationPage({ detail, duplicate, error }: InferGetS
 
       <div className="mt-6 grid gap-4 lg:grid-cols-2">
         <details className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><summary className="cursor-pointer list-none font-semibold">Update disposition <span className="ml-2 text-xs font-normal text-gray-500">secondary</span></summary>
-          <form method="post" action="/api/internal/sales" className="mt-4 grid gap-3"><input type="hidden" name="action" value="update_status" /><input type="hidden" name="organizationId" value={organization.id} /><select name="status" defaultValue={organization.status} className={fieldClass}>{SALES_ORGANIZATION_STATUSES.map((value) => <option key={value}>{value}</option>)}</select><select name="objectionCode" defaultValue={organization.objectionCode || ""} className={fieldClass}><option value="">No objection</option>{SALES_OBJECTION_CODES.map((value) => <option key={value}>{value}</option>)}</select><select name="internalCertificationTeam" defaultValue={organization.internalCertificationTeam == null ? "" : String(organization.internalCertificationTeam)} className={fieldClass}><option value="">Internal team unknown</option><option value="true">Internal team: yes</option><option value="false">Internal team: no</option></select><textarea name="notes" defaultValue={organization.notes} placeholder="Organization notes" className={fieldClass} /><label className="flex items-center gap-2 text-sm"><input type="checkbox" name="doNotContact" defaultChecked={organization.doNotContact} /> Do not contact</label><button className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white">Update disposition</button></form>
+          <form method="post" action="/api/internal/sales" className="mt-4 grid gap-3"><input type="hidden" name="action" value="update_status" /><input type="hidden" name="organizationId" value={organization.id} /><select name="experiment" defaultValue={organization.experiment} className={fieldClass}>{SALES_EXPERIMENTS.map((value) => <option key={value} value={value}>{experimentLabel(value)}</option>)}</select><select name="status" defaultValue={organization.status} className={fieldClass}>{SALES_ORGANIZATION_STATUSES.map((value) => <option key={value}>{value}</option>)}</select><select name="objectionCode" defaultValue={organization.objectionCode || ""} className={fieldClass}><option value="">No objection</option>{SALES_OBJECTION_CODES.map((value) => <option key={value}>{value}</option>)}</select><select name="internalCertificationTeam" defaultValue={organization.internalCertificationTeam == null ? "" : String(organization.internalCertificationTeam)} className={fieldClass}><option value="">Internal team unknown</option><option value="true">Internal team: yes</option><option value="false">Internal team: no</option></select><textarea name="notes" defaultValue={organization.notes} placeholder="Organization notes" className={fieldClass} /><label className="flex items-center gap-2 text-sm"><input type="checkbox" name="doNotContact" defaultChecked={organization.doNotContact} /> Do not contact</label><button className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white">Update disposition</button></form>
         </details>
 
         <details className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><summary className="cursor-pointer list-none font-semibold">Log interaction <span className="ml-2 text-xs font-normal text-gray-500">manual</span></summary>


### PR DESCRIPTION
Adds an experiment classification to the existing internal sales memory so Article6 carbon, Tender Readiness, and EcoVadis / Supplier Compliance leads can live in one CRM without losing shared company/contact history.

Changes:
- adds experiment categories and validation
- adds DB migration for organization experiment classification
- shows experiment badges on the sales index and organization page
- lets new organizations be assigned to an experiment
- lets existing organizations be reclassified during disposition updates
- includes experiment in internal search text

Existing organizations default to Article6 Carbon. We can reconcile the Tender and EcoVadis leads at end of day after the migration is applied.