### PR TITLE
Fix internal sales pipeline filters and persistent search

### DIFF
--- a/components/SalesHeader.tsx
+++ b/components/SalesHeader.tsx
@@ -1,0 +1,55 @@
+import { useRouter } from "next/router";
+import { useState } from "react";
+import SalesMemorySearch, { type SalesMemorySearchEntry } from "./SalesMemorySearch";
+import { SALES_ORGANIZATION_STATUSES, type SalesOrganizationStatus } from "../lib/sales-memory";
+
+export type SalesStatusFilter = "ALL" | SalesOrganizationStatus;
+
+interface Props {
+  entries: SalesMemorySearchEntry[];
+  initialQuery?: string;
+  initialStatus?: SalesStatusFilter;
+  onChange?: (query: string, status: SalesStatusFilter) => void;
+  sectionTitle?: string;
+  sectionCount?: number;
+}
+
+function statusClass(status: SalesStatusFilter, active: boolean) {
+  const activeClass = active ? "ring-2 ring-offset-1 ring-gray-700" : "";
+  if (status === "CLOSED_NO") return `bg-red-100 text-red-800 ${activeClass}`;
+  if (status === "CLOSED_WON") return `bg-emerald-100 text-emerald-800 ${activeClass}`;
+  if (status === "OPPORTUNITY") return `bg-green-100 text-green-800 ${activeClass}`;
+  if (status === "ENGAGED") return `bg-violet-100 text-violet-800 ${activeClass}`;
+  if (status === "NURTURE") return `bg-amber-100 text-amber-800 ${activeClass}`;
+  if (status === "CONTACTED") return `bg-blue-100 text-blue-800 ${activeClass}`;
+  return `bg-gray-100 text-gray-700 ${activeClass}`;
+}
+
+export default function SalesHeader({ entries, initialQuery = "", initialStatus = "ALL", onChange, sectionTitle, sectionCount }: Props) {
+  const router = useRouter();
+  const [query, setQuery] = useState(initialQuery);
+  const [status, setStatus] = useState<SalesStatusFilter>(initialStatus);
+
+  function update(nextQuery: string, nextStatus: SalesStatusFilter) {
+    setQuery(nextQuery);
+    setStatus(nextStatus);
+    onChange?.(nextQuery, nextStatus);
+  }
+
+  function chooseStatus(nextStatus: SalesStatusFilter) {
+    if (onChange) update(query, nextStatus);
+    else router.push({ pathname: "/internal/sales", query: { ...(query ? { q: query } : {}), ...(nextStatus !== "ALL" ? { status: nextStatus } : {}) } });
+  }
+
+  return <>
+    <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
+      <div><h1 className="text-2xl font-bold tracking-tight">Sales memory</h1><p className="mt-2 text-sm text-gray-600">Search first. Keep every experiment in one history so we do not re-contact people blindly.</p></div>
+    </div>
+    <SalesMemorySearch entries={entries} query={query} status={status} onQueryChange={(value) => update(value, status)} />
+    {sectionTitle ? <div className="mt-7 flex flex-wrap items-end justify-between gap-4"><div><h2 className="text-base font-semibold">{sectionTitle}</h2><p className="mt-1 text-xs text-gray-500">Most recently active first.</p></div><span className="text-xs text-gray-500">{sectionCount} total</span></div> : null}
+    <div className="mt-3 flex flex-wrap gap-2" aria-label="Sales status filters">
+      <button type="button" onClick={() => chooseStatus("ALL")} className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${statusClass("ALL", status === "ALL")}`}>ALL</button>
+      {SALES_ORGANIZATION_STATUSES.map((value) => <button type="button" key={value} onClick={() => chooseStatus(value)} className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${statusClass(value, status === value)}`}>{value}</button>)}
+    </div>
+  </>;
+}

--- a/components/SalesMemorySearch.tsx
+++ b/components/SalesMemorySearch.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 export interface SalesMemorySearchEntry {
   key: string;
@@ -22,18 +22,17 @@ function statusClass(status: string) {
   return "bg-gray-100 text-gray-700";
 }
 
-export default function SalesMemorySearch({ entries }: { entries: SalesMemorySearchEntry[] }) {
-  const [query, setQuery] = useState("");
+export default function SalesMemorySearch({ entries, query = "", status = "ALL", onQueryChange }: { entries: SalesMemorySearchEntry[]; query?: string; status?: string; onQueryChange?: (query: string) => void }) {
   const results = useMemo(() => {
     const needle = query.trim().toLowerCase();
     if (needle.length < 2) return [];
-    return entries.filter((entry) => entry.searchText.includes(needle)).slice(0, 12);
-  }, [entries, query]);
+    return entries.filter((entry) => (status === "ALL" || entry.status === status) && entry.searchText.includes(needle)).slice(0, 12);
+  }, [entries, query, status]);
 
   return <div className="relative mt-7">
-    <input value={query} onChange={(event) => setQuery(event.target.value)} autoComplete="off" placeholder="Start typing a VCS ID, project, organization, contact, email, methodology…" className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base shadow-sm outline-none focus:border-forest-600 focus:ring-2 focus:ring-forest-100" />
+    <input value={query} onChange={(event) => onQueryChange?.(event.target.value)} autoComplete="off" placeholder="Start typing a VCS ID, project, organization, contact, email, methodology…" className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base shadow-sm outline-none focus:border-forest-600 focus:ring-2 focus:ring-forest-100" />
     {query.trim().length >= 2 ? <div className="absolute z-20 mt-2 w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
-      {results.length ? <div className="divide-y divide-gray-100">{results.map((result) => <Link key={result.key} href={`/internal/sales/organizations/${result.organizationId}`} className={`block px-4 py-3 hover:bg-gray-50 ${result.doNotContact ? "bg-red-50/60" : ""}`}>
+      {results.length ? <div className="divide-y divide-gray-100">{results.map((result) => <Link key={result.key} href={{ pathname: `/internal/sales/organizations/${result.organizationId}`, query: { q: query, ...(status !== "ALL" ? { status } : {}) } }} className={`block px-4 py-3 hover:bg-gray-50 ${result.doNotContact ? "bg-red-50/60" : ""}`}>
         <div className="flex flex-wrap items-center gap-2"><span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-gray-500">{result.kind.toUpperCase()}</span><span className="text-sm font-semibold text-gray-900">{result.title}</span><span className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${statusClass(result.status)}`}>{result.status}</span>{result.doNotContact ? <span className="rounded bg-red-100 px-2 py-0.5 text-[10px] font-bold text-red-700">DO NOT CONTACT</span> : null}</div>
         <div className="mt-1 text-xs text-gray-500">{result.subtitle}</div>
       </Link>)}</div> : <p className="px-4 py-3 text-sm text-gray-500">No matching sales-memory records.</p>}

--- a/components/SalesOrganizationsTable.tsx
+++ b/components/SalesOrganizationsTable.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { useState } from "react";
+import SalesHeader, { type SalesStatusFilter } from "./SalesHeader";
+import type { SalesMemorySearchEntry } from "./SalesMemorySearch";
+import type { SalesOrganization } from "../lib/sales-store";
+
+function rowClass(status: string, doNotContact: boolean) {
+  if (doNotContact || status === "CLOSED_NO") return "border-l-4 border-red-400 bg-red-50/50 hover:bg-red-50";
+  if (status === "CLOSED_WON" || status === "OPPORTUNITY") return "border-l-4 border-green-400 bg-green-50/40 hover:bg-green-50/70";
+  if (status === "ENGAGED") return "border-l-4 border-violet-400 bg-violet-50/50 hover:bg-violet-50/80";
+  if (status === "NURTURE") return "border-l-4 border-amber-400 bg-amber-50/40 hover:bg-amber-50/70";
+  if (status === "CONTACTED") return "border-l-4 border-blue-300 hover:bg-blue-50/40";
+  return "border-l-4 border-transparent hover:bg-gray-50";
+}
+
+function statusClass(status: string) {
+  if (status === "CLOSED_NO") return "bg-red-100 text-red-800 ring-1 ring-inset ring-red-200";
+  if (status === "CLOSED_WON") return "bg-emerald-100 text-emerald-800 ring-1 ring-inset ring-emerald-200";
+  if (status === "OPPORTUNITY") return "bg-green-100 text-green-800 ring-1 ring-inset ring-green-200";
+  if (status === "ENGAGED") return "bg-violet-100 text-violet-800 ring-1 ring-inset ring-violet-200";
+  if (status === "NURTURE") return "bg-amber-100 text-amber-800 ring-1 ring-inset ring-amber-200";
+  if (status === "CONTACTED") return "bg-blue-100 text-blue-800 ring-1 ring-inset ring-blue-200";
+  return "bg-gray-100 text-gray-700 ring-1 ring-inset ring-gray-200";
+}
+
+function experimentLabel(value: string) {
+  if (value === "ARTICLE6_CARBON") return "Article6 Carbon";
+  if (value === "TENDER_READINESS") return "Tender Readiness";
+  if (value === "ECOVADIS_SUPPLIER_COMPLIANCE") return "EcoVadis / Supplier Compliance";
+  return "Other";
+}
+
+function formatDate(value?: string) {
+  return value ? new Date(value).toLocaleString() : "Never";
+}
+
+export default function SalesOrganizationsTable({ organizations, searchEntries, initialQuery, initialStatus }: { organizations: SalesOrganization[]; searchEntries: SalesMemorySearchEntry[]; initialQuery?: string; initialStatus?: SalesStatusFilter }) {
+  function filterList(query: string, status: SalesStatusFilter) {
+    const needle = query.trim().toLowerCase();
+    const matchingIds = new Set(searchEntries.filter((entry) => needle.length < 2 || entry.searchText.includes(needle)).map((entry) => entry.organizationId));
+    return organizations.filter((organization) => (status === "ALL" || organization.status === status) && matchingIds.has(organization.id));
+  }
+
+  const [visibleOrganizations, setVisibleOrganizations] = useState(() => filterList(initialQuery || "", initialStatus || "ALL"));
+  const [activeQuery, setActiveQuery] = useState(initialQuery || "");
+  const [activeStatus, setActiveStatus] = useState<SalesStatusFilter>(initialStatus || "ALL");
+
+  function filterOrganizations(query: string, status: SalesStatusFilter) {
+    setActiveQuery(query);
+    setActiveStatus(status);
+    setVisibleOrganizations(filterList(query, status));
+  }
+
+  return <>
+    <SalesHeader entries={searchEntries} initialQuery={initialQuery} initialStatus={initialStatus} onChange={filterOrganizations} sectionTitle="Organizations" sectionCount={visibleOrganizations.length} />
+    <div className="mt-3 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      {visibleOrganizations.length === 0 ? <p className="p-6 text-sm text-gray-600">No organizations found.</p> : <div className="overflow-x-auto"><table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+        <thead className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500"><tr><th className="px-5 py-3">Organization</th><th className="px-5 py-3">Experiment</th><th className="px-5 py-3">Status</th><th className="px-5 py-3">Projects</th><th className="px-5 py-3">Last interaction</th><th className="px-5 py-3"><span className="sr-only">Action</span></th></tr></thead>
+        <tbody className="divide-y divide-gray-100">{visibleOrganizations.map((organization) => <tr key={organization.id} className={rowClass(organization.status, organization.doNotContact)}>
+          <td className="px-5 py-4"><div className="font-medium text-gray-900">{organization.name}</div><div className="text-xs text-gray-500">{organization.domain || "No domain"}</div></td>
+          <td className="px-5 py-4"><span className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">{experimentLabel(organization.experiment)}</span></td>
+          <td className="px-5 py-4"><span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${statusClass(organization.status)}`}>{organization.status}</span>{organization.doNotContact ? <div className="mt-1 text-xs font-semibold text-red-700">DO NOT CONTACT</div> : null}</td>
+          <td className="px-5 py-4">{organization.projectCount || 0}</td>
+          <td className="whitespace-nowrap px-5 py-4 text-gray-600">{formatDate(organization.lastInteractionAt)}</td>
+          <td className="px-5 py-4 text-right"><Link href={{ pathname: `/internal/sales/organizations/${organization.id}`, query: { ...(activeQuery ? { q: activeQuery } : {}), ...(activeStatus !== "ALL" ? { status: activeStatus } : {}) } }} className="font-medium text-forest-700 hover:text-forest-800">Open →</Link></td>
+        </tr>)}</tbody>
+      </table></div>}
+    </div>
+  </>;
+}

--- a/lib/sales-memory.ts
+++ b/lib/sales-memory.ts
@@ -6,7 +6,6 @@ export const SALES_ORGANIZATION_STATUSES = [
   "NURTURE",
   "CLOSED_NO",
   "CLOSED_WON",
-  "DO_NOT_CONTACT",
 ] as const;
 
 export type SalesOrganizationStatus = (typeof SALES_ORGANIZATION_STATUSES)[number];

--- a/lib/sales-search.ts
+++ b/lib/sales-search.ts
@@ -1,0 +1,50 @@
+import type { SalesOrganizationDetail } from "./sales-store";
+import type { SalesMemorySearchEntry } from "../components/SalesMemorySearch";
+
+export function buildSalesMemorySearchEntries(details: SalesOrganizationDetail[]): SalesMemorySearchEntry[] {
+  const entries: SalesMemorySearchEntry[] = [];
+
+  for (const detail of details) {
+    const { organization, projects, contacts } = detail;
+    const common = {
+      status: organization.status,
+      doNotContact: organization.doNotContact,
+    };
+
+    entries.push({
+      ...common,
+      key: `organization-${organization.id}`,
+      kind: "organization",
+      organizationId: organization.id,
+      title: organization.name,
+      subtitle: [organization.domain || "No domain", organization.experiment].join(" · "),
+      searchText: [organization.name, organization.domain, organization.experiment].filter(Boolean).join(" ").toLowerCase(),
+    });
+
+    for (const project of projects) {
+      entries.push({
+        ...common,
+        key: `project-${organization.id}-${project.id}`,
+        kind: "project",
+        organizationId: organization.id,
+        title: project.vcsId ? `VCS ${project.vcsId} · ${project.name}` : project.name,
+        subtitle: [organization.name, project.methodology && `${project.methodology}${project.methodologyVersion ? ` ${project.methodologyVersion}` : ""}`].filter(Boolean).join(" · "),
+        searchText: [project.vcsId, project.name, project.methodology, project.methodologyVersion, organization.name, organization.experiment].filter(Boolean).join(" ").toLowerCase(),
+      });
+    }
+
+    for (const contact of contacts) {
+      entries.push({
+        ...common,
+        key: `contact-${organization.id}-${contact.id}`,
+        kind: "contact",
+        organizationId: organization.id,
+        title: contact.name,
+        subtitle: [organization.name, contact.email].filter(Boolean).join(" · "),
+        searchText: [contact.name, contact.email, organization.name, organization.experiment].filter(Boolean).join(" ").toLowerCase(),
+      });
+    }
+  }
+
+  return entries;
+}

--- a/pages/internal/sales/index.tsx
+++ b/pages/internal/sales/index.tsx
@@ -1,85 +1,20 @@
 import Head from "next/head";
 import Link from "next/link";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import SalesMemorySearch, { type SalesMemorySearchEntry } from "../../../components/SalesMemorySearch";
+import SalesOrganizationsTable from "../../../components/SalesOrganizationsTable";
+import { buildSalesMemorySearchEntries } from "../../../lib/sales-search";
 import { getSalesOrganizationDetail, listSalesOrganizations, type SalesOrganization } from "../../../lib/sales-store";
 import { SALES_EXPERIMENTS } from "../../../lib/sales-memory";
 
-interface Props { organizations: SalesOrganization[]; searchEntries: SalesMemorySearchEntry[]; }
+interface Props { organizations: SalesOrganization[]; searchEntries: ReturnType<typeof buildSalesMemorySearchEntries>; initialQuery: string; initialStatus: "ALL" | SalesOrganization["status"]; }
 
-export const getServerSideProps: GetServerSideProps<Props> = async () => {
+export const getServerSideProps: GetServerSideProps<Props> = async ({ query }) => {
   const organizations = await listSalesOrganizations("");
-  const details = await Promise.all(organizations.map((organization) => getSalesOrganizationDetail(organization.id)));
-  const projectEntries: SalesMemorySearchEntry[] = [];
-  const organizationEntries: SalesMemorySearchEntry[] = [];
-  const contactEntries: SalesMemorySearchEntry[] = [];
-
-  for (const detail of details) {
-    if (!detail) continue;
-    const { organization, projects, contacts } = detail;
-    organizationEntries.push({
-      key: `organization-${organization.id}`,
-      kind: "organization",
-      organizationId: organization.id,
-      title: organization.name,
-      subtitle: [organization.domain || "No domain", organization.experiment].join(" · "),
-      searchText: [organization.name, organization.domain, organization.experiment].filter(Boolean).join(" ").toLowerCase(),
-      status: organization.status,
-      doNotContact: organization.doNotContact,
-    });
-
-    for (const project of projects) {
-      projectEntries.push({
-        key: `project-${organization.id}-${project.id}`,
-        kind: "project",
-        organizationId: organization.id,
-        title: project.vcsId ? `VCS ${project.vcsId} · ${project.name}` : project.name,
-        subtitle: [organization.name, project.methodology && `${project.methodology}${project.methodologyVersion ? ` ${project.methodologyVersion}` : ""}`].filter(Boolean).join(" · "),
-        searchText: [project.vcsId, project.name, project.methodology, project.methodologyVersion, organization.name, organization.experiment].filter(Boolean).join(" ").toLowerCase(),
-        status: organization.status,
-        doNotContact: organization.doNotContact,
-      });
-    }
-
-    for (const contact of contacts) {
-      contactEntries.push({
-        key: `contact-${organization.id}-${contact.id}`,
-        kind: "contact",
-        organizationId: organization.id,
-        title: contact.name,
-        subtitle: [organization.name, contact.email].filter(Boolean).join(" · "),
-        searchText: [contact.name, contact.email, organization.name, organization.experiment].filter(Boolean).join(" ").toLowerCase(),
-        status: organization.status,
-        doNotContact: organization.doNotContact,
-      });
-    }
-  }
-
-  return { props: { organizations, searchEntries: [...projectEntries, ...organizationEntries, ...contactEntries] } };
+  const details = (await Promise.all(organizations.map((organization) => getSalesOrganizationDetail(organization.id)))).filter((detail): detail is NonNullable<typeof detail> => Boolean(detail));
+  const rawStatus = typeof query.status === "string" ? query.status : "ALL";
+  const initialStatus = rawStatus === "ALL" || organizations.some((organization) => organization.status === rawStatus) ? rawStatus as Props["initialStatus"] : "ALL";
+  return { props: { organizations, searchEntries: buildSalesMemorySearchEntries(details), initialQuery: typeof query.q === "string" ? query.q : "", initialStatus } };
 };
-
-function formatDate(value?: string) {
-  return value ? new Date(value).toLocaleString() : "Never";
-}
-
-function statusClass(status: string) {
-  if (status === "DO_NOT_CONTACT" || status === "CLOSED_NO") return "bg-red-100 text-red-800 ring-1 ring-inset ring-red-200";
-  if (status === "CLOSED_WON") return "bg-emerald-100 text-emerald-800 ring-1 ring-inset ring-emerald-200";
-  if (status === "OPPORTUNITY") return "bg-green-100 text-green-800 ring-1 ring-inset ring-green-200";
-  if (status === "ENGAGED") return "bg-violet-100 text-violet-800 ring-1 ring-inset ring-violet-200";
-  if (status === "NURTURE") return "bg-amber-100 text-amber-800 ring-1 ring-inset ring-amber-200";
-  if (status === "CONTACTED") return "bg-blue-100 text-blue-800 ring-1 ring-inset ring-blue-200";
-  return "bg-gray-100 text-gray-700 ring-1 ring-inset ring-gray-200";
-}
-
-function rowClass(status: string, doNotContact: boolean) {
-  if (doNotContact || status === "DO_NOT_CONTACT" || status === "CLOSED_NO") return "border-l-4 border-red-400 bg-red-50/50 hover:bg-red-50";
-  if (status === "CLOSED_WON" || status === "OPPORTUNITY") return "border-l-4 border-green-400 bg-green-50/40 hover:bg-green-50/70";
-  if (status === "ENGAGED") return "border-l-4 border-violet-400 bg-violet-50/50 hover:bg-violet-50/80";
-  if (status === "NURTURE") return "border-l-4 border-amber-400 bg-amber-50/40 hover:bg-amber-50/70";
-  if (status === "CONTACTED") return "border-l-4 border-blue-300 hover:bg-blue-50/40";
-  return "border-l-4 border-transparent hover:bg-gray-50";
-}
 
 function experimentLabel(value: string) {
   if (value === "ARTICLE6_CARBON") return "Article6 Carbon";
@@ -88,53 +23,13 @@ function experimentLabel(value: string) {
   return "Other";
 }
 
-const statusLegend = ["NEW", "CONTACTED", "ENGAGED", "NURTURE", "OPPORTUNITY", "CLOSED_WON", "CLOSED_NO"];
-
-export default function SalesIndexPage({ organizations, searchEntries }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  return <>
-    <Head><title>Sales Memory | Article6 Internal</title><meta name="robots" content="noindex,nofollow" /></Head>
+export default function SalesIndexPage({ organizations, searchEntries, initialQuery, initialStatus }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return <><Head><title>Sales Memory | Article6 Internal</title><meta name="robots" content="noindex,nofollow" /></Head>
     <main className="min-h-screen bg-gray-50 px-4 py-10 text-gray-900"><div className="mx-auto max-w-6xl">
       <p className="text-sm font-semibold uppercase tracking-wide text-forest-700">Internal experiments & sales</p>
-      <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
-        <div><h1 className="text-2xl font-bold tracking-tight">Sales memory</h1><p className="mt-2 text-sm text-gray-600">Search first. Keep every experiment in one history so we do not re-contact people blindly.</p></div>
-        <Link href="/internal/sales/import-review" className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700">Review imports</Link>
-      </div>
-
-      <SalesMemorySearch entries={searchEntries} />
-
-      <div className="mt-4 flex justify-end">
-        <details>
-          <summary className="cursor-pointer list-none text-sm font-medium text-gray-500 hover:text-gray-800">+ Add organization manually</summary>
-          <section className="mt-3 rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
-            <form method="post" action="/api/internal/sales" className="grid gap-3 md:grid-cols-5">
-              <input type="hidden" name="action" value="create_organization" />
-              <input required name="name" placeholder="Organization name" className="rounded-md border border-gray-300 px-3 py-2 text-sm" />
-              <input name="domain" placeholder="Domain" className="rounded-md border border-gray-300 px-3 py-2 text-sm" />
-              <input name="country" placeholder="Country" className="rounded-md border border-gray-300 px-3 py-2 text-sm" />
-              <select name="experiment" defaultValue="ARTICLE6_CARBON" className="rounded-md border border-gray-300 px-3 py-2 text-sm">{SALES_EXPERIMENTS.map((value) => <option key={value} value={value}>{experimentLabel(value)}</option>)}</select>
-              <button className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white">Add organization</button>
-            </form>
-          </section>
-        </details>
-      </div>
-
-      <div className="mt-7 flex flex-wrap items-end justify-between gap-4"><div><h2 className="text-base font-semibold">Organizations</h2><p className="mt-1 text-xs text-gray-500">Most recently active first.</p></div><span className="text-xs text-gray-500">{organizations.length} total</span></div>
-      <div className="mt-3 flex flex-wrap gap-2" aria-label="Sales status legend">
-        {statusLegend.map((status) => <span key={status} className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${statusClass(status)}`}>{status}</span>)}
-      </div>
-      <div className="mt-3 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
-        {organizations.length === 0 ? <p className="p-6 text-sm text-gray-600">No organizations found.</p> : <div className="overflow-x-auto"><table className="min-w-full divide-y divide-gray-200 text-left text-sm">
-          <thead className="bg-gray-50 text-xs font-semibold uppercase tracking-wide text-gray-500"><tr><th className="px-5 py-3">Organization</th><th className="px-5 py-3">Experiment</th><th className="px-5 py-3">Status</th><th className="px-5 py-3">Projects</th><th className="px-5 py-3">Last interaction</th><th className="px-5 py-3"><span className="sr-only">Action</span></th></tr></thead>
-          <tbody className="divide-y divide-gray-100">{organizations.map((organization) => <tr key={organization.id} className={rowClass(organization.status, organization.doNotContact)}>
-            <td className="px-5 py-4"><div className="font-medium text-gray-900">{organization.name}</div><div className="text-xs text-gray-500">{organization.domain || "No domain"}</div></td>
-            <td className="px-5 py-4"><span className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">{experimentLabel(organization.experiment)}</span></td>
-            <td className="px-5 py-4"><span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${statusClass(organization.status)}`}>{organization.status}</span>{organization.doNotContact ? <div className="mt-1 text-xs font-semibold text-red-700">DO NOT CONTACT</div> : null}</td>
-            <td className="px-5 py-4">{organization.projectCount || 0}</td>
-            <td className="whitespace-nowrap px-5 py-4 text-gray-600">{formatDate(organization.lastInteractionAt)}</td>
-            <td className="px-5 py-4 text-right"><Link href={`/internal/sales/organizations/${organization.id}`} className="font-medium text-forest-700 hover:text-forest-800">Open →</Link></td>
-          </tr>)}</tbody>
-        </table></div>}
-      </div>
+      <div className="mt-2 flex justify-end"><Link href="/internal/sales/import-review" className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700">Review imports</Link></div>
+      <div className="mt-4 flex justify-end"><details><summary className="cursor-pointer list-none text-sm font-medium text-gray-500 hover:text-gray-800">+ Add organization manually</summary><section className="mt-3 rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><form method="post" action="/api/internal/sales" className="grid gap-3 md:grid-cols-5"><input type="hidden" name="action" value="create_organization" /><input required name="name" placeholder="Organization name" className="rounded-md border border-gray-300 px-3 py-2 text-sm" /><input name="domain" placeholder="Domain" className="rounded-md border border-gray-300 px-3 py-2 text-sm" /><input name="country" placeholder="Country" className="rounded-md border border-gray-300 px-3 py-2 text-sm" /><select name="experiment" defaultValue="ARTICLE6_CARBON" className="rounded-md border border-gray-300 px-3 py-2 text-sm">{SALES_EXPERIMENTS.map((value) => <option key={value} value={value}>{experimentLabel(value)}</option>)}</select><button className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white">Add organization</button></form></section></details></div>
+      <SalesOrganizationsTable organizations={organizations} searchEntries={searchEntries} initialQuery={initialQuery} initialStatus={initialStatus} />
     </div></main>
   </>;
 }

--- a/pages/internal/sales/organizations/[id].tsx
+++ b/pages/internal/sales/organizations/[id].tsx
@@ -1,16 +1,23 @@
 import Head from "next/head";
 import Link from "next/link";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import SalesHeader from "../../../../components/SalesHeader";
+import { buildSalesMemorySearchEntries } from "../../../../lib/sales-search";
+import { listSalesOrganizations } from "../../../../lib/sales-store";
 import { getSalesOrganizationDetail, type SalesOrganizationDetail } from "../../../../lib/sales-store";
 import { SALES_EXPERIMENTS, SALES_OBJECTION_CODES, SALES_ORGANIZATION_STATUSES } from "../../../../lib/sales-memory";
 
-interface Props { detail: SalesOrganizationDetail; duplicate: boolean; error?: string; }
+interface Props { detail: SalesOrganizationDetail; duplicate: boolean; error?: string; searchEntries: ReturnType<typeof buildSalesMemorySearchEntries>; initialQuery: string; initialStatus: "ALL" | SalesOrganizationDetail["organization"]["status"]; }
 
 export const getServerSideProps: GetServerSideProps<Props> = async ({ params, query }) => {
   const id = typeof params?.id === "string" ? params.id : "";
   const detail = await getSalesOrganizationDetail(id);
   if (!detail) return { notFound: true };
-  return { props: { detail, duplicate: query.duplicate === "1", error: typeof query.error === "string" ? query.error : undefined } };
+  const organizations = await listSalesOrganizations("");
+  const details = (await Promise.all(organizations.map((organization) => getSalesOrganizationDetail(organization.id)))).filter((value): value is NonNullable<typeof value> => Boolean(value));
+  const rawStatus = typeof query.status === "string" ? query.status : "ALL";
+  const initialStatus = rawStatus === "ALL" || detail.organization.status === rawStatus ? rawStatus as Props["initialStatus"] : "ALL";
+  return { props: { detail, duplicate: query.duplicate === "1", error: typeof query.error === "string" ? query.error : undefined, searchEntries: buildSalesMemorySearchEntries(details), initialQuery: typeof query.q === "string" ? query.q : "", initialStatus } };
 };
 
 const fieldClass = "rounded-md border border-gray-300 px-3 py-2 text-sm";
@@ -27,7 +34,7 @@ function experimentLabel(value: string) {
   return "Other";
 }
 
-export default function OrganizationPage({ detail, duplicate, error }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function OrganizationPage({ detail, duplicate, error, searchEntries, initialQuery, initialStatus }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { organization, contacts, projects, interactions } = detail;
   const website = websiteHref(organization.domain);
 
@@ -35,6 +42,7 @@ export default function OrganizationPage({ detail, duplicate, error }: InferGetS
     <Head><title>{organization.name} | Sales Memory</title><meta name="robots" content="noindex,nofollow" /></Head>
     <main className="min-h-screen bg-gray-50 px-4 py-10 text-gray-900"><div className="mx-auto max-w-6xl">
       <Link href="/internal/sales" className="text-sm font-medium text-forest-700">← Sales memory</Link>
+      <SalesHeader entries={searchEntries} initialQuery={initialQuery} initialStatus={initialStatus} />
       <div className="mt-4 flex flex-wrap items-start justify-between gap-4">
         <div><h1 className="text-3xl font-bold tracking-tight">{organization.name}</h1><p className="mt-1 text-sm text-gray-600">{organization.domain || "No domain recorded"}{organization.country ? ` · ${organization.country}` : ""}</p><div className="mt-2"><span className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">{experimentLabel(organization.experiment)}</span></div></div>
         <div className="text-right"><div className="text-sm font-semibold">{organization.status}</div>{organization.objectionCode ? <div className="mt-1 text-xs text-gray-500">{organization.objectionCode}</div> : null}{organization.doNotContact ? <div className="mt-2 rounded bg-red-100 px-2 py-1 text-xs font-bold text-red-700">DO NOT CONTACT</div> : null}</div>


### PR DESCRIPTION
## Summary

- Replace the visual-only sales status legend with one functional ALL/status filter row.
- Combine status filtering with organization/contact/project search and remove unsupported pipeline status values.
- Add a shared sales header/search to the organization list and detail pages while preserving query/filter context.

## Testing

- npm run lint: passed
- npx tsc --noEmit: passed
- git diff --check: passed
- npm test: 42 passed, 1 pre-existing failure because Node cannot resolve the extensionless ../lib/sales-memory import in tests/sales-memory.test.ts
- npm run build: compiled and passed lint/type checking; static generation timed out on the unrelated /projects page