### PR TITLE
Fix relationship history conversation rendering

### DIFF
--- a/lib/sales-interaction-display.ts
+++ b/lib/sales-interaction-display.ts
@@ -1,8 +1,32 @@
 export const INTERNAL_SALES_SENDER = "Fred E.";
 export const UNKNOWN_EXTERNAL_SENDER = "External contact";
 
+export type RelationshipHistoryDirection = "OUTBOUND" | "INBOUND";
+
+export interface RelationshipHistoryPresentation {
+  direction: RelationshipHistoryDirection;
+  actorName: string;
+  alignment: "left" | "right";
+  recipient?: string;
+}
+
+export function normalizeRelationshipHistoryDirection(direction: string): RelationshipHistoryDirection {
+  return direction.trim().toUpperCase() === "OUTBOUND" ? "OUTBOUND" : "INBOUND";
+}
+
 export function relationshipHistoryActor(direction: string, contactName?: string): string {
-  return direction.trim().toUpperCase() === "OUTBOUND"
+  return normalizeRelationshipHistoryDirection(direction) === "OUTBOUND"
     ? INTERNAL_SALES_SENDER
     : contactName?.trim() || UNKNOWN_EXTERNAL_SENDER;
+}
+
+export function relationshipHistoryPresentation(direction: string, contactName?: string): RelationshipHistoryPresentation {
+  const normalizedDirection = normalizeRelationshipHistoryDirection(direction);
+  const isOutbound = normalizedDirection === "OUTBOUND";
+  return {
+    direction: normalizedDirection,
+    actorName: relationshipHistoryActor(normalizedDirection, contactName),
+    alignment: isOutbound ? "right" : "left",
+    recipient: isOutbound ? contactName?.trim() || undefined : undefined,
+  };
 }

--- a/lib/sales-store.ts
+++ b/lib/sales-store.ts
@@ -214,7 +214,7 @@ export async function getSalesOrganizationDetail(id: string): Promise<SalesOrgan
   const [contactsResult, projectsResult, interactionsResult] = await Promise.all([
     getPool().query("SELECT * FROM sales_contacts WHERE organization_id = $1 ORDER BY name ASC", [id]),
     getPool().query(`SELECT p.*, op.role FROM sales_organization_projects op JOIN sales_projects p ON p.id = op.project_id WHERE op.organization_id = $1 ORDER BY p.name ASC`, [id]),
-    getPool().query(`SELECT i.*, c.name AS contact_name, p.name AS project_name FROM sales_interactions i LEFT JOIN sales_contacts c ON c.id = i.contact_id LEFT JOIN sales_projects p ON p.id = i.project_id WHERE i.organization_id = $1 ORDER BY i.occurred_at DESC, i.created_at DESC`, [id]),
+    getPool().query(`SELECT i.*, c.name AS contact_name, p.name AS project_name FROM sales_interactions i LEFT JOIN sales_contacts c ON c.id = i.contact_id LEFT JOIN sales_projects p ON p.id = i.project_id WHERE i.organization_id = $1 ORDER BY i.occurred_at ASC, i.created_at ASC`, [id]),
   ]);
   return {
     organization: toOrganization(organizationResult.rows[0]),

--- a/pages/internal/sales/organizations/[id].tsx
+++ b/pages/internal/sales/organizations/[id].tsx
@@ -6,7 +6,7 @@ import { buildSalesMemorySearchEntries } from "../../../../lib/sales-search";
 import { listSalesOrganizations } from "../../../../lib/sales-store";
 import { getSalesOrganizationDetail, type SalesOrganizationDetail } from "../../../../lib/sales-store";
 import { SALES_EXPERIMENTS, SALES_OBJECTION_CODES, SALES_ORGANIZATION_STATUSES } from "../../../../lib/sales-memory";
-import { relationshipHistoryActor } from "../../../../lib/sales-interaction-display";
+import { relationshipHistoryPresentation } from "../../../../lib/sales-interaction-display";
 
 interface Props { detail: SalesOrganizationDetail; duplicate: boolean; error?: string; searchEntries: ReturnType<typeof buildSalesMemorySearchEntries>; initialQuery: string; initialStatus: "ALL" | SalesOrganizationDetail["organization"]["status"]; }
 
@@ -71,11 +71,11 @@ export default function OrganizationPage({ detail, duplicate, error, searchEntri
         </div>
       </section>
 
-      <section className="mt-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><div className="flex flex-wrap items-center justify-between gap-3"><div><h2 className="font-semibold">Relationship history</h2><p className="mt-1 text-xs text-gray-500">Newest interaction first.</p></div><div className="text-xs text-gray-500">{interactions.length} interactions</div></div>
+      <section className="mt-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><div className="flex flex-wrap items-center justify-between gap-3"><div><h2 className="font-semibold">Relationship history</h2><p className="mt-1 text-xs text-gray-500">Oldest interaction first.</p></div><div className="text-xs text-gray-500">{interactions.length} interactions</div></div>
         <div className="mt-5 space-y-5">{interactions.length ? interactions.map((interaction) => {
-          const isOutbound = interaction.direction === "OUTBOUND";
-          const actorName = relationshipHistoryActor(interaction.direction, interaction.contactName);
-          return <article key={interaction.id} className={`flex ${isOutbound ? "justify-end" : "justify-start"}`}><div className={`w-full max-w-3xl rounded-lg border px-4 py-3 ${isOutbound ? "border-blue-100 bg-blue-50" : "border-gray-200 bg-gray-50"}`}><div className="flex flex-wrap items-center gap-2 text-xs text-gray-500"><span>{new Date(interaction.occurredAt).toLocaleString()}</span><span>{interaction.direction} · {interaction.channel} · {interaction.interactionType}</span>{interaction.outcomeCode ? <span className="rounded bg-gray-100 px-2 py-0.5 font-medium text-gray-700">{interaction.outcomeCode}</span> : null}</div><div className="mt-1 text-sm font-medium text-gray-900">{interaction.subject || interaction.contactName || "Interaction"}</div><p className="mt-1 whitespace-pre-wrap text-sm leading-6 text-gray-700">{interaction.summary}</p><div className="mt-1 text-xs text-gray-500">Author: {actorName}</div><div className="mt-1 text-xs text-gray-500">{[interaction.contactName, interaction.projectName].filter(Boolean).join(" · ")}</div></div></article>;
+          const presentation = relationshipHistoryPresentation(interaction.direction, interaction.contactName);
+          const relationshipDetails = [presentation.recipient ? `To: ${presentation.recipient}` : undefined, interaction.projectName].filter(Boolean).join(" · ");
+          return <article key={interaction.id} className={`flex ${presentation.alignment === "right" ? "justify-end" : "justify-start"}`}><div className={`w-full max-w-3xl rounded-lg border px-4 py-3 ${presentation.alignment === "right" ? "border-blue-100 bg-blue-50" : "border-gray-200 bg-gray-50"}`}><div className="flex flex-wrap items-center gap-2 text-xs text-gray-500"><span>{new Date(interaction.occurredAt).toLocaleString()}</span><span>{presentation.direction} · {interaction.channel} · {interaction.interactionType}</span>{interaction.outcomeCode ? <span className="rounded bg-gray-100 px-2 py-0.5 font-medium text-gray-700">{interaction.outcomeCode}</span> : null}</div><div className="mt-1 text-sm font-medium text-gray-900">{interaction.subject || "Interaction"}</div><p className="mt-1 whitespace-pre-wrap text-sm leading-6 text-gray-700">{interaction.summary}</p><div className="mt-1 text-xs text-gray-500">Author: {presentation.actorName}</div>{relationshipDetails ? <div className="mt-1 text-xs text-gray-500">{relationshipDetails}</div> : null}</div></article>;
         }) : <p className="text-sm text-gray-500">No interactions yet.</p>}</div>
       </section>
 

--- a/tests/sales-relationship-history.test.ts
+++ b/tests/sales-relationship-history.test.ts
@@ -1,20 +1,36 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import test from "node:test";
-import { relationshipHistoryActor } from "../lib/sales-interaction-display.ts";
+import { relationshipHistoryPresentation } from "../lib/sales-interaction-display.ts";
 
 test("outbound history uses Fred E. even when a contact is attached", () => {
-  assert.equal(relationshipHistoryActor("OUTBOUND", "John Kealy"), "Fred E.");
+  assert.deepEqual(relationshipHistoryPresentation("OUTBOUND", "John Kealy"), { direction: "OUTBOUND", actorName: "Fred E.", alignment: "right", recipient: "John Kealy" });
 });
 
 test("inbound history uses the contact name", () => {
-  assert.equal(relationshipHistoryActor("INBOUND", "Vijayakumar Rangaraju"), "Vijayakumar Rangaraju");
+  assert.deepEqual(relationshipHistoryPresentation("INBOUND", "Vijayakumar Rangaraju"), { direction: "INBOUND", actorName: "Vijayakumar Rangaraju", alignment: "left", recipient: undefined });
 });
 
-test("mixed conversations alternate actors by direction", () => {
+test("mixed conversations alternate sides and actors by direction", () => {
   const history = [
-    { direction: "OUTBOUND", contactName: "Vijayakumar Rangaraju" },
+    { direction: "inbound", contactName: "Vijayakumar Rangaraju" },
+    { direction: "outbound", contactName: "Vijayakumar Rangaraju" },
     { direction: "INBOUND", contactName: "Vijayakumar Rangaraju" },
-    { direction: "OUTBOUND", contactName: "Vijayakumar Rangaraju" },
   ];
-  assert.deepEqual(history.map((interaction) => relationshipHistoryActor(interaction.direction, interaction.contactName)), ["Fred E.", "Vijayakumar Rangaraju", "Fred E."]);
+  assert.deepEqual(history.map((interaction) => relationshipHistoryPresentation(interaction.direction, interaction.contactName)), [
+    { direction: "INBOUND", actorName: "Vijayakumar Rangaraju", alignment: "left", recipient: undefined },
+    { direction: "OUTBOUND", actorName: "Fred E.", alignment: "right", recipient: "Vijayakumar Rangaraju" },
+    { direction: "INBOUND", actorName: "Vijayakumar Rangaraju", alignment: "left", recipient: undefined },
+  ]);
+});
+
+test("relationship history query returns chronological order without a render-time reverse", () => {
+  const store = fs.readFileSync(new URL("../lib/sales-store.ts", import.meta.url), "utf8");
+  assert.match(store, /ORDER BY i\.occurred_at ASC, i\.created_at ASC/);
+  assert.doesNotMatch(store, /ORDER BY i\.occurred_at DESC, i\.created_at DESC/);
+});
+
+test("inbound history does not expose a second recipient identity", () => {
+  const inbound = relationshipHistoryPresentation("INBOUND", "Vijayakumar Rangaraju");
+  assert.equal(inbound.recipient, undefined);
 });


### PR DESCRIPTION
## Summary
- render relationship history chronologically from oldest to newest
- normalize inbound/outbound direction values for actor and bubble alignment
- keep outbound cards attributed to Fred E. and label recipients as `To: ...`
- remove duplicate contact identity text from inbound cards
- add regression coverage for identity, sides, chronology, normalization, and recipient labeling

## Verification
- `npm test` (51 passed)
- `npx tsc --noEmit`
- `npm run lint`