### PR TITLE
Fix relationship history timeline ordering

### DIFF
--- a/lib/sales-import-store.ts
+++ b/lib/sales-import-store.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "crypto";
 import { Pool, type PoolClient, type QueryResultRow } from "pg";
 import { normalizeDomain, normalizeOrganizationName, isSalesObjectionCode, isSalesOrganizationStatus } from "./sales-memory";
+import { normalizeSalesInteractionTimestamp } from "./sales-timestamps";
 
 export interface SalesImportContact { name: string; title?: string; email?: string; phone?: string; notes?: string; }
 export interface SalesImportProject { vcsId?: string; name: string; methodology?: string; methodologyVersion?: string; stage?: string; country?: string; vvb?: string; role?: string; notes?: string; }
-export interface SalesImportInteraction { contactEmail?: string; projectVcsId?: string; channel?: string; direction?: string; interactionType?: string; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string; }
+export interface SalesImportInteraction { contactEmail?: string; projectVcsId?: string; channel?: string; direction?: string; interactionType?: string; gmailTimestamp?: string | number; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string; }
 
 export interface SalesImportCandidate {
   id: string;
@@ -156,14 +157,13 @@ export async function approveSalesImportCandidate(id: string, explicitOrganizati
       if (vcsId) projectIds.set(vcsId, String(row.id));
     }
     for (const interaction of (candidate.interactions_json || []) as SalesImportInteraction[]) {
-      const parsed = new Date(interaction.occurredAt);
-      if (Number.isNaN(parsed.getTime())) throw new Error("Candidate contains an invalid interaction date.");
+      const occurredAt = normalizeSalesInteractionTimestamp(interaction.gmailTimestamp ?? interaction.occurredAt);
       await client.query(
         `INSERT INTO sales_interactions (id,organization_id,contact_id,project_id,channel,direction,interaction_type,occurred_at,subject,summary,outcome_code,external_reference,created_at)
          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
         [randomUUID(), organizationId, interaction.contactEmail ? contactIds.get(interaction.contactEmail.trim().toLowerCase()) || null : null,
           interaction.projectVcsId ? projectIds.get(interaction.projectVcsId.trim()) || null : null, interaction.channel || "EMAIL", interaction.direction || "INTERNAL",
-          interaction.interactionType || "MESSAGE", parsed.toISOString(), interaction.subject?.trim() || null, interaction.summary.trim(), interaction.outcomeCode?.trim() || null,
+          interaction.interactionType || "MESSAGE", occurredAt, interaction.subject?.trim() || null, interaction.summary.trim(), interaction.outcomeCode?.trim() || null,
           interaction.externalReference?.trim() || null, now]
       );
     }

--- a/lib/sales-store.ts
+++ b/lib/sales-store.ts
@@ -7,6 +7,7 @@ import {
   type SalesObjectionCode,
   type SalesOrganizationStatus,
 } from "./sales-memory";
+import { normalizeSalesInteractionTimestamp } from "./sales-timestamps";
 
 export interface SalesOrganization {
   id: string;
@@ -193,10 +194,11 @@ export async function addSalesProject(input: { organizationId: string; vcsId?: s
 
 export async function addSalesInteraction(input: { organizationId: string; contactId?: string; projectId?: string; channel: string; direction: string; interactionType: string; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string }): Promise<void> {
   const createdAt = new Date().toISOString();
+  const occurredAt = normalizeSalesInteractionTimestamp(input.occurredAt);
   await getPool().query(
     `INSERT INTO sales_interactions (id, organization_id, contact_id, project_id, channel, direction, interaction_type, occurred_at, subject, summary, outcome_code, external_reference, created_at)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
-    [randomUUID(), input.organizationId, input.contactId || null, input.projectId || null, input.channel, input.direction, input.interactionType, input.occurredAt, input.subject?.trim() || null, input.summary.trim(), input.outcomeCode?.trim() || null, input.externalReference?.trim() || null, createdAt]
+    [randomUUID(), input.organizationId, input.contactId || null, input.projectId || null, input.channel, input.direction, input.interactionType, occurredAt, input.subject?.trim() || null, input.summary.trim(), input.outcomeCode?.trim() || null, input.externalReference?.trim() || null, createdAt]
   );
   await getPool().query("UPDATE sales_organizations SET updated_at = $2 WHERE id = $1", [input.organizationId, createdAt]);
 }
@@ -214,12 +216,12 @@ export async function getSalesOrganizationDetail(id: string): Promise<SalesOrgan
   const [contactsResult, projectsResult, interactionsResult] = await Promise.all([
     getPool().query("SELECT * FROM sales_contacts WHERE organization_id = $1 ORDER BY name ASC", [id]),
     getPool().query(`SELECT p.*, op.role FROM sales_organization_projects op JOIN sales_projects p ON p.id = op.project_id WHERE op.organization_id = $1 ORDER BY p.name ASC`, [id]),
-    getPool().query(`SELECT i.*, c.name AS contact_name, p.name AS project_name FROM sales_interactions i LEFT JOIN sales_contacts c ON c.id = i.contact_id LEFT JOIN sales_projects p ON p.id = i.project_id WHERE i.organization_id = $1 ORDER BY i.occurred_at ASC, i.created_at ASC`, [id]),
+    getPool().query(`SELECT i.*, c.name AS contact_name, p.name AS project_name FROM sales_interactions i LEFT JOIN sales_contacts c ON c.id = i.contact_id LEFT JOIN sales_projects p ON p.id = i.project_id WHERE i.organization_id = $1 ORDER BY COALESCE(i.occurred_at, i.created_at) ASC, i.created_at ASC`, [id]),
   ]);
   return {
     organization: toOrganization(organizationResult.rows[0]),
     contacts: contactsResult.rows.map((row) => ({ id: String(row.id), organizationId: String(row.organization_id), name: String(row.name), title: row.title || undefined, email: row.email || undefined, phone: row.phone || undefined, status: String(row.status), notes: String(row.notes || "") })),
     projects: projectsResult.rows.map((row) => ({ id: String(row.id), vcsId: row.vcs_id || undefined, name: String(row.name), methodology: row.methodology || undefined, methodologyVersion: row.methodology_version || undefined, stage: row.stage || undefined, country: row.country || undefined, vvb: row.vvb || undefined, notes: String(row.notes || ""), role: String(row.role) })),
-    interactions: interactionsResult.rows.map((row) => ({ id: String(row.id), organizationId: String(row.organization_id), contactId: row.contact_id || undefined, projectId: row.project_id || undefined, contactName: row.contact_name || undefined, projectName: row.project_name || undefined, channel: String(row.channel), direction: String(row.direction), interactionType: String(row.interaction_type), occurredAt: iso(row.occurred_at), subject: row.subject || undefined, summary: String(row.summary), outcomeCode: row.outcome_code || undefined, externalReference: row.external_reference || undefined })),
+    interactions: interactionsResult.rows.map((row) => ({ id: String(row.id), organizationId: String(row.organization_id), contactId: row.contact_id || undefined, projectId: row.project_id || undefined, contactName: row.contact_name || undefined, projectName: row.project_name || undefined, channel: String(row.channel), direction: String(row.direction), interactionType: String(row.interaction_type), occurredAt: iso(row.occurred_at || row.created_at), subject: row.subject || undefined, summary: String(row.summary), outcomeCode: row.outcome_code || undefined, externalReference: row.external_reference || undefined })),
   };
 }

--- a/lib/sales-timestamps.ts
+++ b/lib/sales-timestamps.ts
@@ -1,0 +1,9 @@
+export type SalesTimestampInput = string | number | Date;
+
+export function normalizeSalesInteractionTimestamp(value: SalesTimestampInput): string {
+  const numericValue = typeof value === "number" ? value : typeof value === "string" && /^\d{10,13}$/.test(value.trim()) ? Number(value) : undefined;
+  const parsedValue = numericValue == null ? value : numericValue < 1_000_000_000_000 ? numericValue * 1000 : numericValue;
+  const parsed = new Date(parsedValue);
+  if (Number.isNaN(parsed.getTime())) throw new Error("Interaction timestamp is invalid.");
+  return parsed.toISOString();
+}

--- a/tests/sales-relationship-history.test.ts
+++ b/tests/sales-relationship-history.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
 import { relationshipHistoryPresentation } from "../lib/sales-interaction-display.ts";
+import { normalizeSalesInteractionTimestamp } from "../lib/sales-timestamps.ts";
 
 test("outbound history uses Fred E. even when a contact is attached", () => {
   assert.deepEqual(relationshipHistoryPresentation("OUTBOUND", "John Kealy"), { direction: "OUTBOUND", actorName: "Fred E.", alignment: "right", recipient: "John Kealy" });
@@ -26,7 +27,7 @@ test("mixed conversations alternate sides and actors by direction", () => {
 
 test("relationship history query returns chronological order without a render-time reverse", () => {
   const store = fs.readFileSync(new URL("../lib/sales-store.ts", import.meta.url), "utf8");
-  assert.match(store, /ORDER BY i\.occurred_at ASC, i\.created_at ASC/);
+  assert.match(store, /ORDER BY COALESCE\(i\.occurred_at, i\.created_at\) ASC, i\.created_at ASC/);
   assert.doesNotMatch(store, /ORDER BY i\.occurred_at DESC, i\.created_at DESC/);
 });
 
@@ -40,4 +41,30 @@ test("conversation cards do not render sender labels or recipient metadata", () 
   assert.doesNotMatch(page, /Author:/);
   assert.doesNotMatch(page, /To: \$\{/);
   assert.doesNotMatch(page, /relationshipDetails/);
+});
+
+test("interaction timestamps normalize to UTC without changing chronology", () => {
+  assert.equal(normalizeSalesInteractionTimestamp("2026-08-21T10:00:00+08:00"), "2026-08-21T02:00:00.000Z");
+  assert.equal(normalizeSalesInteractionTimestamp("1787278800000"), "2026-08-21T02:20:00.000Z");
+});
+
+test("Gmail thread timestamps preserve multiple sends before a timezone-offset reply", () => {
+  const thread = [
+    { subject: "Reply", gmailTimestamp: "2026-08-21T10:05:00+08:00" },
+    { subject: "First send", gmailTimestamp: "2026-08-21T01:00:00Z" },
+    { subject: "Second send", gmailTimestamp: "2026-08-21T01:30:00Z" },
+  ];
+  const ordered = [...thread].sort((a, b) => normalizeSalesInteractionTimestamp(a.gmailTimestamp).localeCompare(normalizeSalesInteractionTimestamp(b.gmailTimestamp)));
+  assert.deepEqual(ordered.map((message) => message.subject), ["First send", "Second send", "Reply"]);
+});
+
+test("imported Gmail timestamps take precedence over fallback occurredAt", () => {
+  const importer = fs.readFileSync(new URL("../lib/sales-import-store.ts", import.meta.url), "utf8");
+  assert.match(importer, /normalizeSalesInteractionTimestamp\(interaction\.gmailTimestamp \?\? interaction\.occurredAt\)/);
+});
+
+test("history orders by interaction time and only falls back to created_at", () => {
+  const store = fs.readFileSync(new URL("../lib/sales-store.ts", import.meta.url), "utf8");
+  assert.match(store, /ORDER BY COALESCE\(i\.occurred_at, i\.created_at\) ASC, i\.created_at ASC/);
+  assert.doesNotMatch(store, /ORDER BY i\.created_at ASC/);
 });


### PR DESCRIPTION
## Summary
- normalize imported interaction and optional Gmail timestamps to UTC before storage
- order relationship history by `occurred_at` chronologically, falling back to `created_at` only when needed
- preserve sender-driven presentation and all existing interaction fields
- add regression coverage for timezone offsets, Gmail timestamp precedence, multiple sends, and chronological rendering

## Verification
- `npm test` (56 passed)
- `npx tsc --noEmit`
- `npm run lint`