### PR TITLE
Add thread-aware relationship history

### DIFF
--- a/lib/sales-conversations.ts
+++ b/lib/sales-conversations.ts
@@ -1,0 +1,83 @@
+import type { SalesInteraction } from "./sales-store";
+
+const FALLBACK_THREAD_WINDOW_MS = 72 * 60 * 60 * 1000;
+
+export interface SalesConversation {
+  id: string;
+  contactId?: string;
+  contactName?: string;
+  gmailThreadId?: string;
+  subject?: string;
+  interactions: SalesInteraction[];
+}
+
+function normalizedSubject(subject?: string): string {
+  return (subject || "").trim().replace(/^(re|fwd?):\s*/i, "").replace(/\s+/g, " ").toLowerCase();
+}
+
+function contactKey(interaction: SalesInteraction): string {
+  return interaction.contactId || `name:${(interaction.contactName || "").trim().toLowerCase()}`;
+}
+
+function sortInteractions(interactions: SalesInteraction[]): SalesInteraction[] {
+  return interactions
+    .map((interaction, index) => ({ interaction, index }))
+    .sort((a, b) => {
+      const timestamp = Date.parse(a.interaction.occurredAt) - Date.parse(b.interaction.occurredAt);
+      return timestamp || a.index - b.index;
+    })
+    .map(({ interaction }) => interaction);
+}
+
+export function groupSalesInteractions(interactions: SalesInteraction[]): SalesConversation[] {
+  const groups: SalesConversation[] = [];
+  const byGmailThread = new Map<string, SalesConversation>();
+  const fallbackGroups = new Map<string, SalesConversation[]>();
+
+  for (const interaction of sortInteractions(interactions)) {
+    let conversation: SalesConversation | undefined;
+    if (interaction.gmailThreadId) {
+      conversation = byGmailThread.get(interaction.gmailThreadId);
+      if (!conversation) {
+        conversation = { id: `gmail:${interaction.gmailThreadId}`, gmailThreadId: interaction.gmailThreadId, interactions: [] };
+        byGmailThread.set(interaction.gmailThreadId, conversation);
+        groups.push(conversation);
+      }
+    } else {
+      if (!interaction.contactId && !interaction.contactName) {
+        conversation = { id: `unassigned:${groups.length}`, interactions: [] };
+        groups.push(conversation);
+      }
+      if (conversation) {
+        conversation.contactId ||= interaction.contactId;
+        conversation.contactName ||= interaction.contactName;
+        conversation.subject ||= interaction.subject;
+        conversation.interactions.push(interaction);
+        continue;
+      }
+      const fallbackKey = `${contactKey(interaction)}:${normalizedSubject(interaction.subject)}`;
+      const candidates = fallbackGroups.get(fallbackKey) || [];
+      const timestamp = Date.parse(interaction.occurredAt);
+      conversation = candidates.find((candidate) => {
+        const last = candidate.interactions[candidate.interactions.length - 1];
+        return Math.abs(timestamp - Date.parse(last.occurredAt)) <= FALLBACK_THREAD_WINDOW_MS;
+      });
+      if (!conversation) {
+        conversation = { id: `inferred:${fallbackKey}:${groups.length}`, interactions: [] };
+        candidates.push(conversation);
+        fallbackGroups.set(fallbackKey, candidates);
+        groups.push(conversation);
+      }
+    }
+
+    conversation.contactId ||= interaction.contactId;
+    conversation.contactName ||= interaction.contactName;
+    conversation.subject ||= interaction.subject;
+    conversation.interactions.push(interaction);
+  }
+
+  return groups.map((conversation) => ({
+    ...conversation,
+    interactions: sortInteractions(conversation.interactions),
+  }));
+}

--- a/lib/sales-import-store.ts
+++ b/lib/sales-import-store.ts
@@ -5,7 +5,7 @@ import { normalizeSalesInteractionTimestamp } from "./sales-timestamps";
 
 export interface SalesImportContact { name: string; title?: string; email?: string; phone?: string; notes?: string; }
 export interface SalesImportProject { vcsId?: string; name: string; methodology?: string; methodologyVersion?: string; stage?: string; country?: string; vvb?: string; role?: string; notes?: string; }
-export interface SalesImportInteraction { contactEmail?: string; projectVcsId?: string; channel?: string; direction?: string; interactionType?: string; gmailTimestamp?: string | number; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string; }
+export interface SalesImportInteraction { contactEmail?: string; projectVcsId?: string; channel?: string; direction?: string; interactionType?: string; gmailThreadId?: string; gmailTimestamp?: string | number; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string; }
 
 export interface SalesImportCandidate {
   id: string;
@@ -159,12 +159,12 @@ export async function approveSalesImportCandidate(id: string, explicitOrganizati
     for (const interaction of (candidate.interactions_json || []) as SalesImportInteraction[]) {
       const occurredAt = normalizeSalesInteractionTimestamp(interaction.gmailTimestamp ?? interaction.occurredAt);
       await client.query(
-        `INSERT INTO sales_interactions (id,organization_id,contact_id,project_id,channel,direction,interaction_type,occurred_at,subject,summary,outcome_code,external_reference,created_at)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+        `INSERT INTO sales_interactions (id,organization_id,contact_id,project_id,channel,direction,interaction_type,occurred_at,subject,summary,outcome_code,external_reference,gmail_thread_id,created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
         [randomUUID(), organizationId, interaction.contactEmail ? contactIds.get(interaction.contactEmail.trim().toLowerCase()) || null : null,
           interaction.projectVcsId ? projectIds.get(interaction.projectVcsId.trim()) || null : null, interaction.channel || "EMAIL", interaction.direction || "INTERNAL",
           interaction.interactionType || "MESSAGE", occurredAt, interaction.subject?.trim() || null, interaction.summary.trim(), interaction.outcomeCode?.trim() || null,
-          interaction.externalReference?.trim() || null, now]
+          interaction.externalReference?.trim() || null, interaction.gmailThreadId?.trim() || null, now]
       );
     }
     if (candidate.proposed_status && isSalesOrganizationStatus(candidate.proposed_status)) {

--- a/lib/sales-store.ts
+++ b/lib/sales-store.ts
@@ -66,6 +66,7 @@ export interface SalesInteraction {
   summary: string;
   outcomeCode?: string;
   externalReference?: string;
+  gmailThreadId?: string;
 }
 
 export interface SalesOrganizationDetail {
@@ -192,13 +193,13 @@ export async function addSalesProject(input: { organizationId: string; vcsId?: s
   return { id: String(projectRow.id), vcsId: projectRow.vcs_id || undefined, name: String(projectRow.name), methodology: projectRow.methodology || undefined, methodologyVersion: projectRow.methodology_version || undefined, stage: projectRow.stage || undefined, country: projectRow.country || undefined, vvb: projectRow.vvb || undefined, notes: String(projectRow.notes || ""), role: input.role?.trim() || "OTHER" };
 }
 
-export async function addSalesInteraction(input: { organizationId: string; contactId?: string; projectId?: string; channel: string; direction: string; interactionType: string; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string }): Promise<void> {
+export async function addSalesInteraction(input: { organizationId: string; contactId?: string; projectId?: string; channel: string; direction: string; interactionType: string; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string; gmailThreadId?: string }): Promise<void> {
   const createdAt = new Date().toISOString();
   const occurredAt = normalizeSalesInteractionTimestamp(input.occurredAt);
   await getPool().query(
-    `INSERT INTO sales_interactions (id, organization_id, contact_id, project_id, channel, direction, interaction_type, occurred_at, subject, summary, outcome_code, external_reference, created_at)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
-    [randomUUID(), input.organizationId, input.contactId || null, input.projectId || null, input.channel, input.direction, input.interactionType, occurredAt, input.subject?.trim() || null, input.summary.trim(), input.outcomeCode?.trim() || null, input.externalReference?.trim() || null, createdAt]
+    `INSERT INTO sales_interactions (id, organization_id, contact_id, project_id, channel, direction, interaction_type, occurred_at, subject, summary, outcome_code, external_reference, gmail_thread_id, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+    [randomUUID(), input.organizationId, input.contactId || null, input.projectId || null, input.channel, input.direction, input.interactionType, occurredAt, input.subject?.trim() || null, input.summary.trim(), input.outcomeCode?.trim() || null, input.externalReference?.trim() || null, input.gmailThreadId?.trim() || null, createdAt]
   );
   await getPool().query("UPDATE sales_organizations SET updated_at = $2 WHERE id = $1", [input.organizationId, createdAt]);
 }
@@ -222,6 +223,6 @@ export async function getSalesOrganizationDetail(id: string): Promise<SalesOrgan
     organization: toOrganization(organizationResult.rows[0]),
     contacts: contactsResult.rows.map((row) => ({ id: String(row.id), organizationId: String(row.organization_id), name: String(row.name), title: row.title || undefined, email: row.email || undefined, phone: row.phone || undefined, status: String(row.status), notes: String(row.notes || "") })),
     projects: projectsResult.rows.map((row) => ({ id: String(row.id), vcsId: row.vcs_id || undefined, name: String(row.name), methodology: row.methodology || undefined, methodologyVersion: row.methodology_version || undefined, stage: row.stage || undefined, country: row.country || undefined, vvb: row.vvb || undefined, notes: String(row.notes || ""), role: String(row.role) })),
-    interactions: interactionsResult.rows.map((row) => ({ id: String(row.id), organizationId: String(row.organization_id), contactId: row.contact_id || undefined, projectId: row.project_id || undefined, contactName: row.contact_name || undefined, projectName: row.project_name || undefined, channel: String(row.channel), direction: String(row.direction), interactionType: String(row.interaction_type), occurredAt: iso(row.occurred_at || row.created_at), subject: row.subject || undefined, summary: String(row.summary), outcomeCode: row.outcome_code || undefined, externalReference: row.external_reference || undefined })),
+    interactions: interactionsResult.rows.map((row) => ({ id: String(row.id), organizationId: String(row.organization_id), contactId: row.contact_id || undefined, projectId: row.project_id || undefined, contactName: row.contact_name || undefined, projectName: row.project_name || undefined, channel: String(row.channel), direction: String(row.direction), interactionType: String(row.interaction_type), occurredAt: iso(row.occurred_at || row.created_at), subject: row.subject || undefined, summary: String(row.summary), outcomeCode: row.outcome_code || undefined, externalReference: row.external_reference || undefined, gmailThreadId: row.gmail_thread_id || undefined })),
   };
 }

--- a/migrations/007_add_sales_interaction_thread.sql
+++ b/migrations/007_add_sales_interaction_thread.sql
@@ -1,0 +1,10 @@
+ALTER TABLE sales_interactions
+  ADD COLUMN IF NOT EXISTS gmail_thread_id TEXT;
+
+CREATE INDEX IF NOT EXISTS sales_interactions_organization_thread_idx
+  ON sales_interactions (organization_id, gmail_thread_id)
+  WHERE gmail_thread_id IS NOT NULL;
+
+-- Do not reinterpret external_reference here: existing imports may contain a
+-- Gmail message id rather than a thread id. The application groups legacy rows
+-- conservatively by contact, subject, and timestamp proximity instead.

--- a/pages/internal/sales/organizations/[id].tsx
+++ b/pages/internal/sales/organizations/[id].tsx
@@ -7,8 +7,9 @@ import { listSalesOrganizations } from "../../../../lib/sales-store";
 import { getSalesOrganizationDetail, type SalesOrganizationDetail } from "../../../../lib/sales-store";
 import { SALES_EXPERIMENTS, SALES_OBJECTION_CODES, SALES_ORGANIZATION_STATUSES } from "../../../../lib/sales-memory";
 import { relationshipHistoryPresentation } from "../../../../lib/sales-interaction-display";
+import { groupSalesInteractions } from "../../../../lib/sales-conversations";
 
-interface Props { detail: SalesOrganizationDetail; duplicate: boolean; error?: string; searchEntries: ReturnType<typeof buildSalesMemorySearchEntries>; initialQuery: string; initialStatus: "ALL" | SalesOrganizationDetail["organization"]["status"]; }
+interface Props { detail: SalesOrganizationDetail; duplicate: boolean; error?: string; searchEntries: ReturnType<typeof buildSalesMemorySearchEntries>; initialQuery: string; initialStatus: "ALL" | SalesOrganizationDetail["organization"]["status"]; selectedContactId?: string; selectedConversationId?: string; }
 
 export const getServerSideProps: GetServerSideProps<Props> = async ({ params, query }) => {
   const id = typeof params?.id === "string" ? params.id : "";
@@ -18,7 +19,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ params, qu
   const details = (await Promise.all(organizations.map((organization) => getSalesOrganizationDetail(organization.id)))).filter((value): value is NonNullable<typeof value> => Boolean(value));
   const rawStatus = typeof query.status === "string" ? query.status : "ALL";
   const initialStatus = rawStatus === "ALL" || detail.organization.status === rawStatus ? rawStatus as Props["initialStatus"] : "ALL";
-  return { props: { detail, duplicate: query.duplicate === "1", error: typeof query.error === "string" ? query.error : undefined, searchEntries: buildSalesMemorySearchEntries(details), initialQuery: typeof query.q === "string" ? query.q : "", initialStatus } };
+  return { props: { detail, duplicate: query.duplicate === "1", error: typeof query.error === "string" ? query.error : undefined, searchEntries: buildSalesMemorySearchEntries(details), initialQuery: typeof query.q === "string" ? query.q : "", initialStatus, selectedContactId: typeof query.contactId === "string" ? query.contactId : undefined, selectedConversationId: typeof query.threadId === "string" ? query.threadId : undefined } };
 };
 
 const fieldClass = "rounded-md border border-gray-300 px-3 py-2 text-sm";
@@ -35,8 +36,10 @@ function experimentLabel(value: string) {
   return "Other";
 }
 
-export default function OrganizationPage({ detail, duplicate, error, searchEntries, initialQuery, initialStatus }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function OrganizationPage({ detail, duplicate, error, searchEntries, initialQuery, initialStatus, selectedContactId, selectedConversationId }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { organization, contacts, projects, interactions } = detail;
+  const allConversations = groupSalesInteractions(interactions);
+  const conversations = allConversations.filter((conversation) => (!selectedContactId || conversation.contactId === selectedContactId) && (!selectedConversationId || conversation.id === selectedConversationId));
   const website = websiteHref(organization.domain);
 
   return <>
@@ -71,16 +74,16 @@ export default function OrganizationPage({ detail, duplicate, error, searchEntri
         </div>
       </section>
 
-      <section className="mt-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><div className="flex flex-wrap items-center justify-between gap-3"><div><h2 className="font-semibold">Relationship history</h2><p className="mt-1 text-xs text-gray-500">Oldest interaction first.</p></div><div className="text-xs text-gray-500">{interactions.length} interactions</div></div>
-        <div className="mt-5 space-y-5">{interactions.length ? interactions.map((interaction) => {
+      <section className="mt-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><div className="flex flex-wrap items-center justify-between gap-3"><div><h2 className="font-semibold">Relationship history</h2><p className="mt-1 text-xs text-gray-500">{selectedContactId || selectedConversationId ? "Conversation view · oldest message first." : "Organization activity grouped by conversation."}</p></div><div className="text-xs text-gray-500">{conversations.reduce((count, conversation) => count + conversation.interactions.length, 0)} messages · {conversations.length} conversations</div></div>
+        <div className="mt-5 space-y-6">{conversations.length ? conversations.map((conversation) => <section key={conversation.id} className="rounded-lg border border-gray-100 bg-gray-50/50 p-4"><div className="flex flex-wrap items-start justify-between gap-2 border-b border-gray-100 pb-3"><div><div className="text-sm font-semibold text-gray-900">{conversation.contactName || "Conversation"}</div><div className="mt-1 text-xs text-gray-500">{conversation.subject || "No subject"} · {conversation.interactions.length} messages</div></div>{selectedConversationId === conversation.id ? <Link href={`/internal/sales/organizations/${organization.id}`} className="text-xs font-medium text-forest-700 hover:underline">All conversations</Link> : <Link href={`/internal/sales/organizations/${organization.id}?threadId=${encodeURIComponent(conversation.id)}`} className="text-xs font-medium text-forest-700 hover:underline">Open conversation</Link>}</div><div className="mt-4 space-y-5">{conversation.interactions.map((interaction) => {
           const presentation = relationshipHistoryPresentation(interaction.direction, interaction.contactName);
           return <article key={interaction.id} className={`flex ${presentation.alignment === "right" ? "justify-end" : "justify-start"}`}><div className={`w-full max-w-3xl rounded-lg border px-4 py-3 ${presentation.alignment === "right" ? "border-blue-100 bg-blue-50" : "border-gray-200 bg-gray-50"}`}><div className="flex flex-wrap items-center gap-2 text-xs text-gray-500"><span>{new Date(interaction.occurredAt).toLocaleString()}</span><span>{presentation.direction} · {interaction.channel} · {interaction.interactionType}</span>{interaction.outcomeCode ? <span className="rounded bg-gray-100 px-2 py-0.5 font-medium text-gray-700">{interaction.outcomeCode}</span> : null}</div><div className="mt-1 text-sm font-medium text-gray-900">{interaction.subject || "Interaction"}</div><p className="mt-1 whitespace-pre-wrap text-sm leading-6 text-gray-700">{interaction.summary}</p></div></article>;
-        }) : <p className="text-sm text-gray-500">No interactions yet.</p>}</div>
+        })}</div></section>) : <p className="text-sm text-gray-500">No conversations yet.</p>}</div>
       </section>
 
       <div className="mt-6 grid gap-6 lg:grid-cols-2">
         <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"><h2 className="font-semibold">Contacts <span className="ml-1 text-xs font-normal text-gray-500">({contacts.length})</span></h2>
-          <div className="mt-3 space-y-3">{contacts.length ? contacts.map((contact) => <div key={contact.id} className="rounded-md border border-gray-100 p-3 text-sm"><div className="font-medium">{contact.name}</div><div className="text-gray-600">{contact.title || "No title"}</div><div className="mt-1 text-xs text-gray-500">
+          <div className="mt-3 space-y-3">{contacts.length ? contacts.map((contact) => <div key={contact.id} className="rounded-md border border-gray-100 p-3 text-sm"><div className="flex items-start justify-between gap-2"><div className="font-medium">{contact.name}</div><Link href={`/internal/sales/organizations/${organization.id}?contactId=${encodeURIComponent(contact.id)}`} className="text-xs font-medium text-forest-700 hover:underline">View history</Link></div><div className="text-gray-600">{contact.title || "No title"}</div><div className="mt-1 text-xs text-gray-500">
             {contact.email ? <div>Email: {contact.email}</div> : null}
             {contact.phone ? <div>Phone: {contact.phone}</div> : null}
             {!contact.email && !contact.phone ? "No contact details" : null}

--- a/tests/sales-relationship-history.test.ts
+++ b/tests/sales-relationship-history.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
+import { groupSalesInteractions } from "../lib/sales-conversations.ts";
 import { relationshipHistoryPresentation } from "../lib/sales-interaction-display.ts";
 import { normalizeSalesInteractionTimestamp } from "../lib/sales-timestamps.ts";
+import type { SalesInteraction } from "../lib/sales-store.ts";
 
 test("outbound history uses Fred E. even when a contact is attached", () => {
   assert.deepEqual(relationshipHistoryPresentation("OUTBOUND", "John Kealy"), { direction: "OUTBOUND", actorName: "Fred E.", alignment: "right", recipient: "John Kealy" });
@@ -67,4 +69,30 @@ test("history orders by interaction time and only falls back to created_at", () 
   const store = fs.readFileSync(new URL("../lib/sales-store.ts", import.meta.url), "utf8");
   assert.match(store, /ORDER BY COALESCE\(i\.occurred_at, i\.created_at\) ASC, i\.created_at ASC/);
   assert.doesNotMatch(store, /ORDER BY i\.created_at ASC/);
+});
+
+function interaction(id: string, contactId: string, contactName: string, occurredAt: string, summary: string, gmailThreadId?: string, subject = "Fred outreach"): SalesInteraction {
+  return { id, organizationId: "org", contactId, contactName, channel: "EMAIL", direction: summary.startsWith("Fred") ? "OUTBOUND" : "INBOUND", interactionType: "MESSAGE", occurredAt, subject, summary, gmailThreadId };
+}
+
+test("separate Gmail threads at one organization never mix contacts", () => {
+  const conversations = groupSalesInteractions([
+    interaction("v1", "vijay", "Vijay", "2026-08-21T09:00:00.000Z", "Fred outreach", "thread-vijay"),
+    interaction("s1", "samrat", "Samrat", "2026-08-21T09:05:00.000Z", "Fred outreach", "thread-samrat"),
+    interaction("v2", "vijay", "Vijay", "2026-08-21T09:10:00.000Z", "Vijay reply", "thread-vijay"),
+  ]);
+  assert.deepEqual(conversations.map((conversation) => conversation.contactName), ["Vijay", "Samrat"]);
+  assert.deepEqual(conversations[0]?.interactions.map((message) => message.id), ["v1", "v2"]);
+  assert.deepEqual(conversations[1]?.interactions.map((message) => message.id), ["s1"]);
+});
+
+test("legacy rows infer a thread only for the same contact and nearby subject", () => {
+  const conversations = groupSalesInteractions([
+    interaction("v1", "vijay", "Vijay", "2026-08-21T09:00:00.000Z", "Fred outreach"),
+    interaction("s1", "samrat", "Samrat", "2026-08-21T09:05:00.000Z", "Fred outreach"),
+    interaction("v2", "vijay", "Vijay", "2026-08-21T09:10:00.000Z", "Vijay reply", undefined, "Re: Fred outreach"),
+  ]);
+  assert.equal(conversations.length, 2);
+  assert.deepEqual(conversations.find((conversation) => conversation.contactName === "Vijay")?.interactions.map((message) => message.id), ["v1", "v2"]);
+  assert.deepEqual(conversations.find((conversation) => conversation.contactName === "Samrat")?.interactions.map((message) => message.id), ["s1"]);
 });


### PR DESCRIPTION
## Summary
- add nullable Gmail thread identity to sales interactions and preserve it through imports
- group organization interactions into separate contact/thread conversations
- use exact Gmail thread IDs when available and conservative contact/subject/time inference for legacy rows
- add contact-focused and conversation-focused history links without changing organization filters/status behavior
- retain chronological ordering and sender-driven bubble alignment within each conversation

## Verification
- `npm test` (58 passed)
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build` compiled successfully, but the existing static worker timed out generating unrelated `/projects` pages after 60 seconds