### PR TITLE
Fix Gmail-style relationship conversation grouping

### DIFF
--- a/lib/sales-conversations.ts
+++ b/lib/sales-conversations.ts
@@ -12,7 +12,14 @@ export interface SalesConversation {
 }
 
 function normalizedSubject(subject?: string): string {
-  return (subject || "").trim().replace(/^(re|fwd?):\s*/i, "").replace(/\s+/g, " ").toLowerCase();
+  return (subject || "")
+    .trim()
+    .replace(/^(?:(?:re|fw|fwd):\s*)+/i, "")
+    .replace(/[\u2010-\u2015-]+/g, " ")
+    .replace(/[^\w]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
 }
 
 function contactKey(interaction: SalesInteraction): string {
@@ -27,6 +34,25 @@ function sortInteractions(interactions: SalesInteraction[]): SalesInteraction[] 
       return timestamp || a.index - b.index;
     })
     .map(({ interaction }) => interaction);
+}
+
+function addInteraction(conversation: SalesConversation, interaction: SalesInteraction): void {
+  conversation.contactId ||= interaction.contactId;
+  conversation.contactName ||= interaction.contactName;
+  conversation.subject ||= interaction.subject;
+  conversation.interactions.push(interaction);
+}
+
+function nearbyFallbackCandidates(
+  fallbackGroups: Map<string, SalesConversation[]>,
+  subject: string,
+  timestamp: number,
+): SalesConversation[] {
+  return Array.from(fallbackGroups.values()).reduce<SalesConversation[]>((all, candidates) => all.concat(candidates), []).filter((candidate) => {
+    if (normalizedSubject(candidate.subject) !== subject) return false;
+    const last = candidate.interactions[candidate.interactions.length - 1];
+    return Boolean(last) && Math.abs(timestamp - Date.parse(last.occurredAt)) <= FALLBACK_THREAD_WINDOW_MS;
+  });
 }
 
 export function groupSalesInteractions(interactions: SalesInteraction[]): SalesConversation[] {
@@ -44,36 +70,33 @@ export function groupSalesInteractions(interactions: SalesInteraction[]): SalesC
         groups.push(conversation);
       }
     } else {
-      if (!interaction.contactId && !interaction.contactName) {
-        conversation = { id: `unassigned:${groups.length}`, interactions: [] };
-        groups.push(conversation);
-      }
-      if (conversation) {
-        conversation.contactId ||= interaction.contactId;
-        conversation.contactName ||= interaction.contactName;
-        conversation.subject ||= interaction.subject;
-        conversation.interactions.push(interaction);
-        continue;
-      }
-      const fallbackKey = `${contactKey(interaction)}:${normalizedSubject(interaction.subject)}`;
-      const candidates = fallbackGroups.get(fallbackKey) || [];
+      const subject = normalizedSubject(interaction.subject);
       const timestamp = Date.parse(interaction.occurredAt);
-      conversation = candidates.find((candidate) => {
+      const fallbackKey = `${contactKey(interaction)}:${subject}`;
+      const contactCandidates = fallbackGroups.get(fallbackKey) || [];
+      conversation = contactCandidates.find((candidate) => {
         const last = candidate.interactions[candidate.interactions.length - 1];
         return Math.abs(timestamp - Date.parse(last.occurredAt)) <= FALLBACK_THREAD_WINDOW_MS;
       });
+
+      // Older imports may not have linked the contact on an inbound row. If
+      // exactly one known contact thread has the same subject nearby, it is
+      // safe to attach the message to that thread. Ambiguous messages remain
+      // separate rather than being assigned to the wrong person.
+      if (!conversation && !interaction.contactId && !interaction.contactName) {
+        const nearby = nearbyFallbackCandidates(fallbackGroups, subject, timestamp);
+        if (nearby.length === 1) conversation = nearby[0];
+      }
+
       if (!conversation) {
         conversation = { id: `inferred:${fallbackKey}:${groups.length}`, interactions: [] };
-        candidates.push(conversation);
-        fallbackGroups.set(fallbackKey, candidates);
+        contactCandidates.push(conversation);
+        fallbackGroups.set(fallbackKey, contactCandidates);
         groups.push(conversation);
       }
     }
 
-    conversation.contactId ||= interaction.contactId;
-    conversation.contactName ||= interaction.contactName;
-    conversation.subject ||= interaction.subject;
-    conversation.interactions.push(interaction);
+    addInteraction(conversation, interaction);
   }
 
   return groups.map((conversation) => ({

--- a/lib/sales-import-store.ts
+++ b/lib/sales-import-store.ts
@@ -28,6 +28,7 @@ export interface SalesImportCandidate {
 }
 
 let pool: Pool | undefined;
+let gmailThreadColumnAvailable: Promise<boolean> | undefined;
 function getPool(): Pool {
   if (pool) return pool;
   const connectionString = process.env.POSTGRES_URL || process.env.DATABASE_URL;
@@ -38,6 +39,20 @@ function getPool(): Pool {
     ...(process.env.NODE_ENV === "production" ? { ssl: { rejectUnauthorized: true } } : connectionString.includes("localhost") ? { ssl: false } : {}),
   });
   return pool;
+}
+
+async function hasGmailThreadColumn(): Promise<boolean> {
+  if (!gmailThreadColumnAvailable) {
+    gmailThreadColumnAvailable = getPool().query(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = 'sales_interactions'
+           AND column_name = 'gmail_thread_id'
+       ) AS available`
+    ).then((result) => Boolean(result.rows[0]?.available));
+  }
+  return gmailThreadColumnAvailable;
 }
 
 function toCandidate(row: QueryResultRow): SalesImportCandidate {
@@ -114,6 +129,7 @@ export async function approveSalesImportCandidate(id: string, explicitOrganizati
   const client = await getPool().connect();
   try {
     await client.query("BEGIN");
+    const hasThreadColumn = await hasGmailThreadColumn();
     const result = await client.query("SELECT * FROM sales_import_candidates WHERE id=$1 FOR UPDATE", [id]);
     const candidate = result.rows[0];
     if (!candidate) throw new Error("Import candidate not found.");
@@ -158,14 +174,21 @@ export async function approveSalesImportCandidate(id: string, explicitOrganizati
     }
     for (const interaction of (candidate.interactions_json || []) as SalesImportInteraction[]) {
       const occurredAt = normalizeSalesInteractionTimestamp(interaction.gmailTimestamp ?? interaction.occurredAt);
-      await client.query(
-        `INSERT INTO sales_interactions (id,organization_id,contact_id,project_id,channel,direction,interaction_type,occurred_at,subject,summary,outcome_code,external_reference,gmail_thread_id,created_at)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
-        [randomUUID(), organizationId, interaction.contactEmail ? contactIds.get(interaction.contactEmail.trim().toLowerCase()) || null : null,
-          interaction.projectVcsId ? projectIds.get(interaction.projectVcsId.trim()) || null : null, interaction.channel || "EMAIL", interaction.direction || "INTERNAL",
-          interaction.interactionType || "MESSAGE", occurredAt, interaction.subject?.trim() || null, interaction.summary.trim(), interaction.outcomeCode?.trim() || null,
-          interaction.externalReference?.trim() || null, interaction.gmailThreadId?.trim() || null, now]
-      );
+      const values = [randomUUID(), organizationId, interaction.contactEmail ? contactIds.get(interaction.contactEmail.trim().toLowerCase()) || null : null,
+        interaction.projectVcsId ? projectIds.get(interaction.projectVcsId.trim()) || null : null, interaction.channel || "EMAIL", interaction.direction || "INTERNAL",
+        interaction.interactionType || "MESSAGE", occurredAt, interaction.subject?.trim() || null, interaction.summary.trim(), interaction.outcomeCode?.trim() || null,
+        interaction.externalReference?.trim() || null];
+      if (hasThreadColumn) {
+        await client.query(
+          `INSERT INTO sales_interactions (id,organization_id,contact_id,project_id,channel,direction,interaction_type,occurred_at,subject,summary,outcome_code,external_reference,gmail_thread_id,created_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`, [...values, interaction.gmailThreadId?.trim() || null, now]
+        );
+      } else {
+        await client.query(
+          `INSERT INTO sales_interactions (id,organization_id,contact_id,project_id,channel,direction,interaction_type,occurred_at,subject,summary,outcome_code,external_reference,created_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`, [...values, now]
+        );
+      }
     }
     if (candidate.proposed_status && isSalesOrganizationStatus(candidate.proposed_status)) {
       const objection = candidate.proposed_objection && isSalesObjectionCode(candidate.proposed_objection) ? candidate.proposed_objection : null;

--- a/lib/sales-store.ts
+++ b/lib/sales-store.ts
@@ -77,6 +77,7 @@ export interface SalesOrganizationDetail {
 }
 
 let pool: Pool | undefined;
+let gmailThreadColumnAvailable: Promise<boolean> | undefined;
 function getPool(): Pool {
   if (pool) return pool;
   const connectionString = process.env.POSTGRES_URL || process.env.DATABASE_URL;
@@ -91,6 +92,20 @@ function getPool(): Pool {
         : {}),
   });
   return pool;
+}
+
+async function hasGmailThreadColumn(): Promise<boolean> {
+  if (!gmailThreadColumnAvailable) {
+    gmailThreadColumnAvailable = getPool().query(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = 'sales_interactions'
+           AND column_name = 'gmail_thread_id'
+       ) AS available`
+    ).then((result) => Boolean(result.rows[0]?.available));
+  }
+  return gmailThreadColumnAvailable;
 }
 
 function iso(value: unknown): string {
@@ -196,11 +211,21 @@ export async function addSalesProject(input: { organizationId: string; vcsId?: s
 export async function addSalesInteraction(input: { organizationId: string; contactId?: string; projectId?: string; channel: string; direction: string; interactionType: string; occurredAt: string; subject?: string; summary: string; outcomeCode?: string; externalReference?: string; gmailThreadId?: string }): Promise<void> {
   const createdAt = new Date().toISOString();
   const occurredAt = normalizeSalesInteractionTimestamp(input.occurredAt);
-  await getPool().query(
-    `INSERT INTO sales_interactions (id, organization_id, contact_id, project_id, channel, direction, interaction_type, occurred_at, subject, summary, outcome_code, external_reference, gmail_thread_id, created_at)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
-    [randomUUID(), input.organizationId, input.contactId || null, input.projectId || null, input.channel, input.direction, input.interactionType, occurredAt, input.subject?.trim() || null, input.summary.trim(), input.outcomeCode?.trim() || null, input.externalReference?.trim() || null, input.gmailThreadId?.trim() || null, createdAt]
-  );
+  const hasThreadColumn = await hasGmailThreadColumn();
+  const values = [randomUUID(), input.organizationId, input.contactId || null, input.projectId || null, input.channel, input.direction, input.interactionType, occurredAt, input.subject?.trim() || null, input.summary.trim(), input.outcomeCode?.trim() || null, input.externalReference?.trim() || null];
+  if (hasThreadColumn) {
+    await getPool().query(
+      `INSERT INTO sales_interactions (id, organization_id, contact_id, project_id, channel, direction, interaction_type, occurred_at, subject, summary, outcome_code, external_reference, gmail_thread_id, created_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+      [...values, input.gmailThreadId?.trim() || null, createdAt]
+    );
+  } else {
+    await getPool().query(
+      `INSERT INTO sales_interactions (id, organization_id, contact_id, project_id, channel, direction, interaction_type, occurred_at, subject, summary, outcome_code, external_reference, created_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+      [...values, createdAt]
+    );
+  }
   await getPool().query("UPDATE sales_organizations SET updated_at = $2 WHERE id = $1", [input.organizationId, createdAt]);
 }
 
@@ -214,10 +239,12 @@ export async function updateSalesOrganizationState(input: { organizationId: stri
 export async function getSalesOrganizationDetail(id: string): Promise<SalesOrganizationDetail | null> {
   const organizationResult = await getPool().query("SELECT * FROM sales_organizations WHERE id = $1 LIMIT 1", [id]);
   if (!organizationResult.rows[0]) return null;
+  const hasThreadColumn = await hasGmailThreadColumn();
+  const threadSelect = hasThreadColumn ? "i.gmail_thread_id" : "NULL::text AS gmail_thread_id";
   const [contactsResult, projectsResult, interactionsResult] = await Promise.all([
     getPool().query("SELECT * FROM sales_contacts WHERE organization_id = $1 ORDER BY name ASC", [id]),
     getPool().query(`SELECT p.*, op.role FROM sales_organization_projects op JOIN sales_projects p ON p.id = op.project_id WHERE op.organization_id = $1 ORDER BY p.name ASC`, [id]),
-    getPool().query(`SELECT i.*, c.name AS contact_name, p.name AS project_name FROM sales_interactions i LEFT JOIN sales_contacts c ON c.id = i.contact_id LEFT JOIN sales_projects p ON p.id = i.project_id WHERE i.organization_id = $1 ORDER BY COALESCE(i.occurred_at, i.created_at) ASC, i.created_at ASC`, [id]),
+    getPool().query(`SELECT i.*, ${threadSelect} FROM sales_interactions i LEFT JOIN sales_contacts c ON c.id = i.contact_id LEFT JOIN sales_projects p ON p.id = i.project_id WHERE i.organization_id = $1 ORDER BY COALESCE(i.occurred_at, i.created_at) ASC, i.created_at ASC`, [id]),
   ]);
   return {
     organization: toOrganization(organizationResult.rows[0]),

--- a/tests/sales-relationship-history.test.ts
+++ b/tests/sales-relationship-history.test.ts
@@ -96,3 +96,38 @@ test("legacy rows infer a thread only for the same contact and nearby subject", 
   assert.deepEqual(conversations.find((conversation) => conversation.contactName === "Vijay")?.interactions.map((message) => message.id), ["v1", "v2"]);
   assert.deepEqual(conversations.find((conversation) => conversation.contactName === "Samrat")?.interactions.map((message) => message.id), ["s1"]);
 });
+
+test("legacy reply subjects with separators and prefixes stay in one conversation", () => {
+  const conversations = groupSalesInteractions([
+    interaction("v1", "vijay", "Vijay", "2026-08-21T09:00:00.000Z", "Fred outreach", undefined, "HIM Evergreen / VCS 5973 — validation readiness"),
+    interaction("v2", "vijay", "Vijay", "2026-08-21T09:10:00.000Z", "Vijay reply", undefined, "Re: HIM Evergreen / VCS 5973 validation readiness"),
+  ]);
+  assert.equal(conversations.length, 1);
+  assert.deepEqual(conversations[0]?.interactions.map((message) => message.id), ["v1", "v2"]);
+});
+
+test("an unlinked inbound message joins the only nearby matching contact thread", () => {
+  const unlinked = interaction("v2", "", "", "2026-08-21T09:10:00.000Z", "Vijay reply", undefined, "Re: HIM Evergreen / VCS 5973 validation readiness");
+  unlinked.contactId = undefined;
+  unlinked.contactName = undefined;
+  const conversations = groupSalesInteractions([
+    interaction("v1", "vijay", "Vijay", "2026-08-21T09:00:00.000Z", "Fred outreach", undefined, "HIM Evergreen / VCS 5973 — validation readiness"),
+    unlinked,
+  ]);
+  assert.equal(conversations.length, 1);
+  assert.equal(conversations[0]?.contactName, "Vijay");
+  assert.deepEqual(conversations[0]?.interactions.map((message) => message.id), ["v1", "v2"]);
+});
+
+test("unlinked messages remain separate when nearby threads are ambiguous", () => {
+  const unlinked = interaction("reply", "", "", "2026-08-21T09:10:00.000Z", "Reply", undefined, "Re: Shared subject");
+  unlinked.contactId = undefined;
+  unlinked.contactName = undefined;
+  const conversations = groupSalesInteractions([
+    interaction("vijay", "vijay", "Vijay", "2026-08-21T09:00:00.000Z", "Outreach", undefined, "Shared subject"),
+    interaction("samrat", "samrat", "Samrat", "2026-08-21T09:01:00.000Z", "Outreach", undefined, "Shared subject"),
+    unlinked,
+  ]);
+  assert.equal(conversations.length, 3);
+  assert.equal(conversations[2]?.contactName, undefined);
+});


### PR DESCRIPTION
## Summary
- normalize legacy Gmail subjects so reply variants stay in one conversation
- safely attach unlinked inbound messages when exactly one nearby contact thread matches
- keep ambiguous messages isolated to prevent cross-contact mixing
- allow sales history and imports to operate while the `gmail_thread_id` migration is rolling out

## Verification
- `npm test` (61 passing)
- `npm run build` compiles and passes type checking; Next static generation later timed out on the existing `/projects` worker after 60 seconds

## Scope
- No interaction content, timestamps, statuses, tags, filters, or ordering data changed.
- Known Gmail thread IDs remain authoritative.
