### PR TITLE
Fix long-running relationship thread grouping

### DIFF
--- a/lib/sales-conversations.ts
+++ b/lib/sales-conversations.ts
@@ -1,6 +1,8 @@
 import type { SalesInteraction } from "./sales-store";
 
-const FALLBACK_THREAD_WINDOW_MS = 72 * 60 * 60 * 1000;
+// Gmail threads can remain active for weeks. This only applies when a legacy
+// row has no Gmail thread id; known Gmail thread ids remain authoritative.
+const FALLBACK_THREAD_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 export interface SalesConversation {
   id: string;

--- a/lib/sales-store.ts
+++ b/lib/sales-store.ts
@@ -244,7 +244,7 @@ export async function getSalesOrganizationDetail(id: string): Promise<SalesOrgan
   const [contactsResult, projectsResult, interactionsResult] = await Promise.all([
     getPool().query("SELECT * FROM sales_contacts WHERE organization_id = $1 ORDER BY name ASC", [id]),
     getPool().query(`SELECT p.*, op.role FROM sales_organization_projects op JOIN sales_projects p ON p.id = op.project_id WHERE op.organization_id = $1 ORDER BY p.name ASC`, [id]),
-    getPool().query(`SELECT i.*, ${threadSelect} FROM sales_interactions i LEFT JOIN sales_contacts c ON c.id = i.contact_id LEFT JOIN sales_projects p ON p.id = i.project_id WHERE i.organization_id = $1 ORDER BY COALESCE(i.occurred_at, i.created_at) ASC, i.created_at ASC`, [id]),
+    getPool().query(`SELECT i.*, c.name AS contact_name, p.name AS project_name, ${threadSelect} FROM sales_interactions i LEFT JOIN sales_contacts c ON c.id = i.contact_id LEFT JOIN sales_projects p ON p.id = i.project_id WHERE i.organization_id = $1 ORDER BY COALESCE(i.occurred_at, i.created_at) ASC, i.created_at ASC`, [id]),
   ]);
   return {
     organization: toOrganization(organizationResult.rows[0]),

--- a/tests/sales-relationship-history.test.ts
+++ b/tests/sales-relationship-history.test.ts
@@ -106,6 +106,16 @@ test("legacy reply subjects with separators and prefixes stay in one conversatio
   assert.deepEqual(conversations[0]?.interactions.map((message) => message.id), ["v1", "v2"]);
 });
 
+test("a legacy Gmail conversation can span more than 72 hours", () => {
+  const conversations = groupSalesInteractions([
+    interaction("v1", "vijay", "Vijay", "2026-08-16T06:59:12.000Z", "Fred outreach", undefined, "HIM Evergreen / VCS 5973 — validation readiness"),
+    interaction("v2", "vijay", "Vijay", "2026-08-20T10:30:23.000Z", "Fred sample", undefined, "Re: HIM Evergreen / VCS 5973 — validation readiness"),
+    interaction("v3", "vijay", "Vijay", "2026-08-20T11:09:17.000Z", "Vijay reply", undefined, "HIM Evergreen / VCS 5973 validation readiness"),
+  ]);
+  assert.equal(conversations.length, 1);
+  assert.deepEqual(conversations[0]?.interactions.map((message) => message.id), ["v1", "v2", "v3"]);
+});
+
 test("an unlinked inbound message joins the only nearby matching contact thread", () => {
   const unlinked = interaction("v2", "", "", "2026-08-21T09:10:00.000Z", "Vijay reply", undefined, "Re: HIM Evergreen / VCS 5973 validation readiness");
   unlinked.contactId = undefined;


### PR DESCRIPTION
## Root cause
The Vijay records are all present in production and share the same contact and normalized subject. The first outbound occurred 99 hours before the next Vijay message, but legacy fallback grouping only searched a 72-hour window, so it created a separate conversation.

The merged query also dropped the `contact_name` and `project_name` select aliases, which caused generic `Conversation` headers.

## Fix
- extend legacy fallback matching to 30 days for conversations without a Gmail thread ID
- preserve exact Gmail thread IDs as authoritative
- restore contact/project aliases in the relationship query
- add regression coverage for the 99-hour Vijay thread

## Verification
- `npm test`: 62 passing
- exact Vijay reproduction groups messages as `1,3,4` chronologically
- `npm run build`: compiled and passed type checking; static generation was not allowed to continue past the existing Next worker timeout

No database records or interaction content were changed.
